### PR TITLE
feat: support for unix timestamps in ms when coercing time formats

### DIFF
--- a/conf/Coercers.go
+++ b/conf/Coercers.go
@@ -107,6 +107,10 @@ var DefaultCoercers = struct {
 				return nil, fmt.Errorf("failed to parse time: %v", err)
 			}
 			return tim, nil
+		case int:
+			return time.Unix(int64(v), 0), nil
+		case int64:
+			return time.Unix(v, 0), nil
 		default:
 			return nil, fmt.Errorf("input data is an unsupported type to coerce to time.Time: %v", data)
 		}

--- a/conf/Coercers_test.go
+++ b/conf/Coercers_test.go
@@ -117,6 +117,8 @@ func TestTimeCoercer(t *testing.T) {
 		{input: now, want: now},
 		{input: "2024-09-09T00:00:00.000Z", want: time.Date(2024, 9, 9, 0, 0, 0, 0, time.UTC)},
 		{input: 1.23, err: true},
+		{input: int(1733007600), want: time.Date(2024, 12, 1, 0, 0, 0, 0, time.Local)},
+		{input: int64(1733007600), want: time.Date(2024, 12, 1, 0, 0, 0, 0, time.Local)},
 	}
 
 	for _, test := range tests {

--- a/conf/Coercers_test.go
+++ b/conf/Coercers_test.go
@@ -117,8 +117,7 @@ func TestTimeCoercer(t *testing.T) {
 		{input: now, want: now},
 		{input: "2024-09-09T00:00:00.000Z", want: time.Date(2024, 9, 9, 0, 0, 0, 0, time.UTC)},
 		{input: 1.23, err: true},
-		{input: int(1733007600), want: time.Date(2024, 12, 1, 0, 0, 0, 0, time.Local)},
-		{input: int64(1733007600), want: time.Date(2024, 12, 1, 0, 0, 0, 0, time.Local)},
+		{input: 1733007600, want: time.Unix(1733007600, 0)},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This brings support for unix timestamps to the default time coercer