### PR TITLE
Fix unclear README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ func main() {
     "firstname": "Zog", // Note we are using "firstname" here as specified in the struct tag
     "age": "", // won't return an error because fields are optional by default
   }
-  errsMap := schema.Parse(m, &u)
+  errsMap := userSchema.Parse(m, &u)
   if errsMap != nil {
     // handle errors -> see Errors section
   }
@@ -102,7 +102,7 @@ func main() {
   Name: "Zog",
   Age: 1,
   }
-  errsMap := schema.Validate(&u)
+  errsMap := userSchema.Validate(&u)
   if errsMap != nil {
     // handle errors -> see Errors section
   }

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -44,7 +44,7 @@ func main() {
     "firstname": "Zog", // Note we are using "firstname" here as specified in the struct tag
     "age": "", // won't return an error because fields are optional by default
   }
-  errsMap := schema.Parse(m, &u)
+  errsMap := userSchema.Parse(m, &u)
   if errsMap != nil {
     // handle errors -> see Errors section
   }
@@ -62,7 +62,7 @@ func main() {
   Name: "Zog",
   Age: 1,
   }
-  errsMap := schema.Validate(&u)
+  errsMap := userSchema.Validate(&u)
   if errsMap != nil {
     // handle errors -> see Errors section
   }


### PR DESCRIPTION
In the README, first a `userSchema` is defined, but then `schema.Parse` is used. I think it should be `userSchema` here, both to make the code clearer and compile when copy/pasted. Same thing with `schema.Validate`.

![image](https://github.com/user-attachments/assets/5b7ddb1c-7b2a-476e-9a88-c7d3964b42e2)
