### PR TITLE
ZogErr Value() doesn't return underlying value

### DIFF
--- a/internals/errors.go
+++ b/internals/errors.go
@@ -58,7 +58,7 @@ func (e *ZogErr) Code() zconst.ZogErrCode {
 
 // value that caused the error
 func (e *ZogErr) Value() any {
-	return e.Value
+	return e.Val
 }
 func (e *ZogErr) SValue(v any) ZogError {
 	e.Val = v


### PR DESCRIPTION
ZogErr Value() returns itself (a func) instead of the value that caused the error as described in the docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Corrected error reporting to ensure that accurate error information is displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->