### PR TITLE
docs: fixed minor typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Killer Features:
 > **API Stability:**
 >
 > - I will consider the API stable when we reach v1.0.0
-> - However, I believe very little API changes will happen from the current implementation. The APIs are are most likely to change are the **data providers** (please don't make your own if possible use the helpers whose APIs will not change meaningfully) and the ParseCtx most other APIs should remain the same
+> - However, I believe very little API changes will happen from the current implementation. The APIs most likely to change are the **data providers** (please don't make your own if possible use the helpers whose APIs will not change meaningfully) and the ParseCtx most other APIs should remain the same
 > - Zog will not respect semver until v1.0.0 is released. Expect breaking changes (mainly in non basic apis) until then.
 
 ## Introduction

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -24,5 +24,5 @@ Killer Features:
 > **API Stability:**
 >
 > - I will consider the API stable when we reach v1.0.0
-> - However, I believe very little API changes will happen from the current implementation. The APIs are are most likely to change are the **data providers** (please don't make your own if possible use the helpers whose APIs will not change meaningfully) and the Ctx most other APIs should remain the same
+> - However, I believe very little API changes will happen from the current implementation. The APIs most likely to change are the **data providers** (please don't make your own if possible use the helpers whose APIs will not change meaningfully) and the Ctx most other APIs should remain the same
 > - Zog will not respect semver until v1.0.0 is released. Expect breaking changes (mainly in non basic apis) until then.


### PR DESCRIPTION
Fixed minor typo in `README` and `index.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity in the API stability section by correcting a typographical error in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->