### PR TITLE
fix!: structs can no longer be required or optional. Define this in the fields instead. If you need to model a struct that might exist use a pointer to a struct. This should not affect most users as now it works how everyone intuitively thought it worked.

### DIFF
--- a/docs/docs/core-concepts/1-anatomy-of-schema.md
+++ b/docs/docs/core-concepts/1-anatomy-of-schema.md
@@ -8,7 +8,7 @@ A zog schema is an interface implemented by multiple custom structs that represe
 
 ```go
 stringSchema := z.String().Min(3).Required().Trim() // A zod schema that represents a required string string of minimum 3 characters and will be trimmed for white space
-userSchema := z.Struct(z.Schema{"name": stringSchema}).Required() // a zod schema that represents a user struct. Also yes I know that z.Schema might be confusing but think of it as the schema for the struct not a ZogSchema
+userSchema := z.Struct(z.Schema{"name": stringSchema}) // a zod schema that represents a user struct. Also yes I know that z.Schema might be confusing but think of it as the schema for the struct not a ZogSchema
 ```
 
 **The string schema, for example, looks something like this:**

--- a/docs/docs/packages/zhttp.md
+++ b/docs/docs/packages/zhttp.md
@@ -36,6 +36,11 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 
 > **WARNING** The `zhttp` package does NOT currently support parsing into any data type that is NOT a struct.
 
+
+## Behaviour on unmarshal errors
+
+if the json, form or query params are not valid, a top level `ZogIssue` will be generated with the `IssueCode` `IssueCodeInvalidJSON` or `IssueCodeZHTTPInvalidForm` or `IssueCodeZHTTPInvalidQuery` and the schema will not be run.
+
 ## Complex Forms
 
 If you need to parse complex forms or query params such as those parsed by packages like [qs](https://www.npmjs.com/package/qs), for example:

--- a/docs/docs/packages/zjson.md
+++ b/docs/docs/packages/zjson.md
@@ -33,3 +33,8 @@ func ParseJson(json []byte) {
 ```
 
 > **WARNING** The `zjson` package does NOT currently support parsing into any data type that is NOT a struct.
+
+
+## Behaviour on unmarshal errors
+
+if the json is not valid, a top level `ZogIssue` will be generated with the `IssueCode` `IssueCodeInvalidJSON` and the schema will not be run.

--- a/docs/docs/zog-schemas.md
+++ b/docs/docs/zog-schemas.md
@@ -138,6 +138,7 @@ z.Time(z.Time.Format(time.RFC3339)) // If input is a string, it will be parsed a
 ## Complex Types
 
 ### Structs
+> Note structs cannot be required or optional. They just pass through to the underlying ZogSchemas for their fields. If you need to express that a struct might exist and if it does it must be valid, you can use a pointer. i.e `z.Ptr(z.Struct(z.Schema{...}))`
 
 ```go
 // usage

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -31,7 +31,7 @@ func TestSetLanguagesErrsMap(t *testing.T) {
 	// Define a schema for testing
 	schema := zog.Struct(zog.Schema{
 		"name": zog.String().Required(),
-	}).Required()
+	})
 
 	// Test cases
 	testCases := []struct {

--- a/pointers_test.go
+++ b/pointers_test.go
@@ -88,8 +88,9 @@ func TestPtrPtrInStruct(t *testing.T) {
 	}
 	var out TestStruct
 	// empty input
-	err := s.Parse("", &out)
-	assert.Empty(t, err)
+	err := s.Parse(nil, &out)
+	assert.NotNil(t, err)
+	assert.Equal(t, zconst.IssueCodeCoerce, err[zconst.ISSUE_KEY_ROOT][0].Code())
 	assert.Nil(t, out.Value)
 
 	// good input

--- a/struct_validate_test.go
+++ b/struct_validate_test.go
@@ -65,19 +65,13 @@ func TestValidateStructNestedStructs(t *testing.T) {
 
 	v2 := struct {
 		Str    string
-		I      int
 		Schema struct {
 			Str string
-			I   int
 		}
 	}{
-		I: 10,
 		Schema: struct {
 			Str string
-			I   int
-		}{
-			I: 10,
-		},
+		}{},
 	}
 
 	errs = validateNestedSchema.Validate(&v2)
@@ -93,15 +87,15 @@ func TestValidateStructOptional(t *testing.T) {
 		Tim time.Time
 	}
 
-	var validateOptionalSchema = Struct(Schema{
+	var validateOptionalSchema = Ptr(Struct(Schema{
 		"str": String().Required(),
 		"in":  Int().Required(),
 		"fl":  Float().Required(),
 		"bol": Bool().Required(),
 		"tim": Time().Required(),
-	}).Required().Optional() // should override required
+	}))
 
-	var o TestStruct
+	var o *TestStruct
 	errs := validateOptionalSchema.Validate(&o)
 	assert.Empty(t, errs)
 }
@@ -218,14 +212,14 @@ func TestValidateStructPostTransforms(t *testing.T) {
 	assert.Equal(t, "post_original", output.Value)
 }
 
-func TestValidateStructRequired(t *testing.T) {
+func TestValidateStructPassThroughRequired(t *testing.T) {
 	type TestStruct struct {
 		Somefield string
 	}
 
 	schema := Struct(Schema{
 		"somefield": String().Required(),
-	}).Required(Message("custom_required"))
+	})
 
 	output := TestStruct{
 		Somefield: "someValue",
@@ -238,8 +232,7 @@ func TestValidateStructRequired(t *testing.T) {
 	var output2 TestStruct
 	errs = schema.Validate(&output2)
 	assert.NotEmpty(t, errs)
-	assert.NotEmpty(t, errs["$root"])
-	assert.Equal(t, "custom_required", errs["$root"][0].Message())
+	assert.Equal(t, zconst.IssueCodeRequired, errs["somefield"][0].Code())
 }
 
 func TestValidateStructGetType(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated schema documentation to clarify validation rules, including handling of optional complex types.
  - Added sections detailing error behavior when provided input is invalid.

- **Bug Fixes**
  - Enhanced error handling during data parsing to ensure more consistent and informative validation feedback.

- **Tests**
  - Expanded test coverage for nested JSON parsing and improved error detection in optional and required schema scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->