### PR TITLE
fix: zhttp supports more complex content type strings

### DIFF
--- a/zhttp/zhttp.go
+++ b/zhttp/zhttp.go
@@ -3,6 +3,7 @@ package zhttp
 import (
 	"net/http"
 	"net/url"
+	"strings"
 
 	p "github.com/Oudwins/zog/internals"
 	"github.com/Oudwins/zog/parsers/zjson"
@@ -75,7 +76,9 @@ func (u urlDataProvider) GetUnderlying() any {
 // schema.Parse(zhttp.Request(r), &dest)
 // WARNING: FOR JSON PARSING DOES NOT SUPPORT JSON ARRAYS OR PRIMITIVES
 func Request(r *http.Request) p.DpFactory {
-	switch r.Header.Get("Content-Type") {
+	// Content-Type follows this format: Content-Type: <media-type> [; parameter=value]
+	typ, _, _ := strings.Cut(r.Header.Get("Content-Type"), ";")
+	switch typ {
 	case "application/json":
 		return Config.Parsers.JSON(r)
 	case "application/x-www-form-urlencoded":

--- a/zhttp/zhttp_test.go
+++ b/zhttp/zhttp_test.go
@@ -192,6 +192,17 @@ func TestParseJsonValid(t *testing.T) {
 	assert.Equal(t, float64(30), dp.Get("age"))
 }
 
+func TestParseJsonWithComplexContentType(t *testing.T) {
+	jsonData := `{"name":"John","age":30}`
+	req, _ := http.NewRequest("POST", "/test", strings.NewReader(jsonData))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	dp, err := Config.Parsers.JSON(req)()
+	assert.Nil(t, err)
+	assert.Equal(t, "John", dp.Get("name"))
+	assert.Equal(t, float64(30), dp.Get("age"))
+}
+
 func TestParseJsonInvalid(t *testing.T) {
 	invalidJSON := `{"name":"John","age":30`
 	req, _ := http.NewRequest("POST", "/test", strings.NewReader(invalidJSON))


### PR DESCRIPTION
Addresses #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of the Content-Type header by extracting only the media type, ensuring consistent request routing even when extra parameters (e.g., charset) are present.
- **Tests**
	- Expanded test coverage to validate JSON parsing with complex Content-Type headers, including scenarios with charset specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->