### PR TITLE
docs: clarify semver version 0 concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Killer Features:
 >
 > - I will consider the API stable when we reach v1.0.0
 > - However, I believe very little API changes will happen from the current implementation. The APIs most likely to change are the **data providers** (please don't make your own if possible use the helpers whose APIs will not change meaningfully) and the z.Ctx most other APIs should remain the same. I could be wrong but I don't expect many breaking changes.
-> - Remember that in semver version 0, minor versions can potentially have breaking changes.
+> - Although we want to keep breaking changes to a minimum, Zog is still in version 0 and will have breaking changes in the minor versions as per semver. So please be careful when upgrading minor versions.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Killer Features:
 >
 > - I will consider the API stable when we reach v1.0.0
 > - However, I believe very little API changes will happen from the current implementation. The APIs most likely to change are the **data providers** (please don't make your own if possible use the helpers whose APIs will not change meaningfully) and the z.Ctx most other APIs should remain the same. I could be wrong but I don't expect many breaking changes.
-> - Zog will not respect semver until v1.0.0 is released. Consider each minor version to potentially have breaking changes until then.
+> - Remember that in semver version 0, minor versions can potentially have breaking changes.
 
 ## Introduction
 


### PR DESCRIPTION
SemVer actually specifies that [version zero is not stable](https://semver.org/#spec-item-4). It's a misconception that minor version changes in v0 are to be non breaking. Many stick to the convention that in v0, minor versions are breaking and patch versions are non breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised the documentation to clarify API stability during the pre-release phase. The updated note informs users that, in semantic versioning version 0, minor updates can include breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->