### PR TITLE
style: apply gofmt to code examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,18 @@ go get github.com/Oudwins/zog
 
 ```go
 import (
-  z "github.com/Oudwins/zog"
-   )
-
+	z "github.com/Oudwins/zog"
+)
 
 type User struct {
-  Name string `zog:"firstname"` // tag is optional. If not set zog will check for "name" field in the input data
-  Age int
+	Name string `zog:"firstname"` // tag is optional. If not set zog will check for "name" field in the input data
+	Age  int
 }
 
 var userSchema = z.Struct(z.Schema{
-  // its very important that schema keys like "name" match the struct field name NOT the input data
-  "name": z.String().Min(3, z.Message("Override default message")).Max(10),
-  "age": z.Int().GT(18)
+	// its very important that schema keys like "name" match the struct field name NOT the input data
+	"name": z.String().Min(3, z.Message("Override default message")).Max(10),
+	"age":  z.Int().GT(18),
 })
 ```
 
@@ -80,19 +79,19 @@ var userSchema = z.Struct(z.Schema{
 
 ```go
 func main() {
-  u := User{}
-  m := map[string]string{
-    "firstname": "Zog", // Note we are using "firstname" here as specified in the struct tag
-    "age": "", // won't return an error because fields are optional by default
-  }
-  errsMap := userSchema.Parse(m, &u)
-  if errsMap != nil {
-    // handle errors -> see Errors section
-  }
-  u.Name // "Zog"
-  // note that this might look weird but we didn't say age was required so Zog just skipped the empty string and we are left with the uninitialized int
-  // If we need 0 to be a valid value for age we can use a pointer to an int which will be nil if the value was not present in the input data
-  u.Age // 0
+	u := User{}
+	m := map[string]string{
+		"firstname": "Zog", // Note we are using "firstname" here as specified in the struct tag
+		"age":       "",    // won't return an error because fields are optional by default
+	}
+	errsMap := userSchema.Parse(m, &u)
+	if errsMap != nil {
+		// handle errors -> see Errors section
+	}
+	u.Name // "Zog"
+	// note that this might look weird but we didn't say age was required so Zog just skipped the empty string and we are left with the uninitialized int
+	// If we need 0 to be a valid value for age we can use a pointer to an int which will be nil if the value was not present in the input data
+	u.Age // 0
 }
 ```
 
@@ -100,14 +99,14 @@ func main() {
 
 ```go
 func main() {
-  u := User{
-  Name: "Zog",
-  Age: 0, // wont return an error because fields are optional by default otherwise it will error
-  }
-  errsMap := userSchema.Validate(&u)
-  if errsMap != nil {
-    // handle errors -> see Errors section
-  }
+	u := User{
+		Name: "Zog",
+		Age:  0, // wont return an error because fields are optional by default otherwise it will error
+	}
+	errsMap := userSchema.Validate(&u)
+	if errsMap != nil {
+		// handle errors -> see Errors section
+	}
 }
 ```
 
@@ -117,8 +116,9 @@ The [zhttp package](https://zog.dev/packages/zhttp) has you covered for JSON, Fo
 
 ```go
 import (
-  zhttp "github.com/Oudwins/zog/zhttp"
-   )
+	zhttp "github.com/Oudwins/zog/zhttp"
+)
+
 err := userSchema.Parse(zhttp.Request(r), &user)
 ```
 
@@ -126,8 +126,9 @@ If you are receiving json some other way you can use the [zjson package](https:/
 
 ```go
 import (
-  zjson "github.com/Oudwins/zog/zjson"
-   )
+	zjson "github.com/Oudwins/zog/zjson"
+)
+
 err := userSchema.Parse(zjson.Decode(bytes.NewReader(jsonBytes)), &user)
 ```
 
@@ -137,8 +138,9 @@ The [zenv package](https://zog.dev/packages/zenv) has you covered, just do:
 
 ```go
 import (
-  zenv "github.com/Oudwins/zog/zenv"
-   )
+	zenv "github.com/Oudwins/zog/zenv"
+)
+
 err := envSchema.Parse(zenv.NewDataProvider(), &envs)
 ```
 
@@ -154,14 +156,14 @@ errsList := Time().Required().Parse("2020-01-01T00:00:00Z", &t)
 ```go
 var dest []string
 Slice(String().Email().Required()).PreTransform(func(data any, ctx z.Ctx) (any, error) {
-  s := data.(string)
-  return strings.Split(s, ","), nil
+	s := data.(string)
+	return strings.Split(s, ","), nil
 }).PostTransform(func(destPtr any, ctx z.Ctx) error {
-  s := destPtr.(*[]string)
-  for i, v := range *s {
-    (*s)[i] = strings.TrimSpace(v)
-  }
-  return nil
+	s := destPtr.(*[]string)
+	for i, v := range *s {
+		(*s)[i] = strings.TrimSpace(v)
+	}
+	return nil
 }).Parse("foo@bar.com,bar@foo.com", &dest) // dest = [foo@bar.com bar@foo.com]
 ```
 


### PR DESCRIPTION
Applied `gofmt` formatting to make the code prettier, there was also a missing trailing comma issue in one of them, which is actually a syntax error in Go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced code example formatting for improved readability and consistent presentation in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->