### PR TITLE
fix!: Allow empty strings during parsing to not trigger required. Instead do .Min(1).

### DIFF
--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -30,7 +30,7 @@ func TestSetLanguagesErrsMap(t *testing.T) {
 
 	// Define a schema for testing
 	schema := zog.Struct(zog.Schema{
-		"name": zog.String().Required(),
+		"name": zog.String().Required().Min(1),
 	})
 
 	// Test cases
@@ -44,21 +44,21 @@ func TestSetLanguagesErrsMap(t *testing.T) {
 		{
 			name:        "English error message",
 			lang:        "en",
-			input:       map[string]interface{}{"name": ""},
+			input:       map[string]interface{}{},
 			expectedErr: true,
 			expected:    "is required",
 		},
 		{
 			name:        "Spanish error message",
 			lang:        "es",
-			input:       map[string]interface{}{"name": ""},
+			input:       map[string]interface{}{},
 			expectedErr: true,
 			expected:    "es requerido",
 		},
 		{
 			name:        "Default to English when language not found",
 			lang:        "fr",
-			input:       map[string]interface{}{"name": ""},
+			input:       map[string]interface{}{},
 			expectedErr: true,
 			expected:    "is required",
 		},
@@ -76,12 +76,16 @@ func TestSetLanguagesErrsMap(t *testing.T) {
 			var dest struct {
 				Name string
 			}
+			n, ok := tc.input["name"]
+			if !ok {
+				n = ""
+			}
 			dest2 := struct {
 				Name string
 				Age  int
 			}{
 				Age:  1,
-				Name: tc.input["name"].(string),
+				Name: n.(string),
 			}
 			errs := schema.Parse(tc.input, &dest, zog.WithCtxValue(LangKey, tc.lang))
 			errs2 := schema.Validate(&dest2, zog.WithCtxValue(LangKey, tc.lang))
@@ -117,7 +121,7 @@ func TestLangErrsMapWithLangKey(t *testing.T) {
 	dest := ""
 	destSchema := zog.String().Required()
 
-	errs := destSchema.Parse("", &dest, zog.WithCtxValue("customLangKey", "es"))
+	errs := destSchema.Parse(nil, &dest, zog.WithCtxValue("customLangKey", "es"))
 
 	assert.NotNil(t, errs, "Expected errors, got nil")
 	assert.Equal(t, "es requerido", errs[0].Message, "Unexpected error message")

--- a/internals/DataProviders.go
+++ b/internals/DataProviders.go
@@ -72,7 +72,11 @@ type MapDataProvider[T any] struct {
 }
 
 func (m *MapDataProvider[T]) Get(key string) any {
-	return any(m.M[key])
+	v, ok := m.M[key]
+	if !ok {
+		return nil
+	}
+	return v
 }
 
 // returns value + key used

--- a/internals/zeroValues.go
+++ b/internals/zeroValues.go
@@ -2,7 +2,6 @@ package internals
 
 import (
 	"reflect"
-	"strings"
 )
 
 type IsZeroValueFunc = func(val any, ctx Ctx) bool
@@ -15,12 +14,5 @@ func IsZeroValue(x any) bool {
 
 // checks if the value is the zero value but only for parsing purposes (i.e the parse function)
 func IsParseZeroValue(val any, ctx Ctx) bool {
-	if val == nil {
-		return true
-	}
-	s, ok := val.(string)
-	if ok {
-		return strings.TrimSpace(s) == ""
-	}
-	return false
+	return val == nil
 }

--- a/numbers_custom_test.go
+++ b/numbers_custom_test.go
@@ -73,7 +73,7 @@ func TestCustomNumberRequired(t *testing.T) {
 	}
 	assert.Equal(t, MyInt(5), dest)
 	dest = 0
-	errs = validator.Parse("", &dest)
+	errs = validator.Parse(nil, &dest)
 	if len(errs) == 0 {
 		t.Errorf("Expected errors, got none")
 	}
@@ -83,7 +83,7 @@ func TestCustomNumberRequired(t *testing.T) {
 	if len(errs) == 0 {
 		t.Errorf("Expected errors, got none")
 	}
-	assert.Equal(t, "custom", errs[0].Message)
+	assert.Equal(t, zconst.IssueCodeCoerce, errs[0].Code)
 
 	errs = validator.Parse(nil, &dest)
 	if len(errs) == 0 {

--- a/numbers_int64_test.go
+++ b/numbers_int64_test.go
@@ -54,13 +54,13 @@ func TestInt64Required(t *testing.T) {
 	if len(errs) == 0 {
 		t.Errorf("Expected errors, got none")
 	}
-	assert.Equal(t, "custom", errs[0].Message)
+	assert.Equal(t, zconst.IssueCodeCoerce, errs[0].Code)
 
 	errs = validator.Parse("     ", &dest)
 	if len(errs) == 0 {
 		t.Errorf("Expected errors, got none")
 	}
-	assert.Equal(t, "custom", errs[0].Message)
+	assert.Equal(t, zconst.IssueCodeCoerce, errs[0].Code)
 
 	errs = validator.Parse(nil, &dest)
 	if len(errs) == 0 {

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -65,13 +65,13 @@ func TestNumberRequired(t *testing.T) {
 	if len(errs) == 0 {
 		t.Errorf("Expected errors, got none")
 	}
-	assert.Equal(t, "custom", errs[0].Message)
+	assert.Equal(t, zconst.IssueCodeCoerce, errs[0].Code)
 
 	errs = validator.Parse("     ", &dest)
 	if len(errs) == 0 {
 		t.Errorf("Expected errors, got none")
 	}
-	assert.Equal(t, "custom", errs[0].Message)
+	assert.Equal(t, zconst.IssueCodeCoerce, errs[0].Code)
 
 	errs = validator.Parse(nil, &dest)
 	if len(errs) == 0 {

--- a/pointers_test.go
+++ b/pointers_test.go
@@ -12,7 +12,7 @@ func TestPtrPrimitive(t *testing.T) {
 	// in := 10
 	var out *int
 	s := Ptr(Int().Required())
-	err := s.Parse("", &out)
+	err := s.Parse(nil, &out)
 	assert.Empty(t, err)
 	assert.Nil(t, out)
 

--- a/pointers_test.go
+++ b/pointers_test.go
@@ -179,17 +179,18 @@ func TestPtrRequired(t *testing.T) {
 	tests := []struct {
 		Val         any
 		ExpectedErr bool
+		ErrCode     string
 	}{
-		{nil, true},
-		{"", true},
-		{0, false},
-		{false, false},
+		{nil, true, zconst.IssueCodeNotNil},
+		{"", false, ""},
+		{0, false, ""},
+		{false, false, ""},
 	}
 	for _, test := range tests {
 		err := schema.Parse(test.Val, &dest)
 		if test.ExpectedErr {
 			assert.NotNil(t, err)
-			assert.Equal(t, "Testing", err[zconst.ISSUE_KEY_ROOT][0].Message)
+			assert.Equal(t, test.ErrCode, err[zconst.ISSUE_KEY_ROOT][0].Code)
 		} else {
 			assert.Nil(t, err)
 		}

--- a/string_custom_test.go
+++ b/string_custom_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Oudwins/zog/conf"
 	"github.com/Oudwins/zog/internals"
 	"github.com/Oudwins/zog/tutils"
+	"github.com/Oudwins/zog/zconst"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,13 +40,14 @@ func TestCustomStringBasics(t *testing.T) {
 	assert.Equal(t, Env(""), data)
 
 	// Test required
-	s = MyStringSchema().Required()
+	s = MyStringSchema().Required().Min(1)
 	err = s.Parse("", &data)
 	assert.NotNil(t, err)
+	assert.Equal(t, zconst.IssueCodeMin, err[0].Code)
 
 	// Test default value
 	s = MyStringSchema().Default(A)
-	err = s.Parse("", &data)
+	err = s.Parse(nil, &data)
 	assert.Nil(t, err)
 	assert.Equal(t, A, data)
 

--- a/string_test.go
+++ b/string_test.go
@@ -14,14 +14,14 @@ func TestStringOptionalByDefault(t *testing.T) {
 	field := String().Len(3).Contains("foo").HasPrefix("pre").HasSuffix("fix")
 	var dest string
 
-	errs := field.Parse("", &dest)
+	errs := field.Parse(nil, &dest)
 	assert.Empty(t, errs)
 
 	assert.Equal(t, "", dest)
 
 	field = field.Required()
 
-	errs = field.Parse("", &dest)
+	errs = field.Parse(nil, &dest)
 	assert.NotEmpty(t, errs)
 	tutils.VerifyDefaultIssueMessages(t, errs)
 
@@ -102,7 +102,7 @@ func TestStringRequired(t *testing.T) {
 	field := String().Required(Message("a"))
 	var dest string
 
-	errs := field.Parse("", &dest)
+	errs := field.Parse(nil, &dest)
 	assert.NotEmpty(t, errs)
 	assert.Equal(t, errs[0].Message, "a")
 
@@ -116,7 +116,7 @@ func TestStringDefault(t *testing.T) {
 	field := String().Default("bar")
 	var dest string
 
-	errs := field.Parse("", &dest)
+	errs := field.Parse(nil, &dest)
 	assert.Empty(t, errs)
 
 	assert.Equal(t, "bar", dest)
@@ -304,7 +304,7 @@ func TestStringOneOf(t *testing.T) {
 	// Test with empty string
 	errs = field.Parse("", &dest)
 	assert.NotEmpty(t, errs)
-	assert.Equal(t, "custom required", errs[0].Message)
+	assert.Equal(t, "custom one of", errs[0].Message)
 
 	// Test with nil
 	errs = field.Parse(nil, &dest)

--- a/struct_test.go
+++ b/struct_test.go
@@ -129,6 +129,41 @@ func TestStructOptional(t *testing.T) {
 	assert.Nil(t, errs)
 }
 
+func TestStructOptionalFields(t *testing.T) {
+	type TestStruct struct {
+		Str string `zog:"str"`
+		In  int    `zog:"in"`
+		Fl  float64
+		Bol bool
+		Tim time.Time
+	}
+
+	var objSchema = Struct(Schema{
+		"str": String(),
+		"in":  Int().Required(),
+		"fl":  Float(),
+		"bol": Bool().Required(),
+		"tim": Time(),
+	})
+
+	var o TestStruct
+	errs := objSchema.Parse(map[string]any{
+		"in":  10,
+		"bol": false,
+	}, &o)
+	assert.Nil(t, errs)
+	assert.Equal(t, o.In, 10)
+	assert.Equal(t, o.Str, "")
+	assert.Equal(t, o.Fl, 0.0)
+	assert.Equal(t, o.Bol, false)
+	assert.Equal(t, o.Tim, time.Time{})
+	errs = objSchema.Parse(map[string]any{}, &o)
+	assert.NotNil(t, errs)
+	assert.Equal(t, zconst.IssueCodeRequired, errs["in"][0].Code)
+	assert.Equal(t, zconst.IssueCodeRequired, errs["bol"][0].Code)
+	tutils.VerifyDefaultIssueMessagesMap(t, errs)
+}
+
 func TestStructCustomTestInSchema(t *testing.T) {
 	type CustomStruct struct {
 		Str string `zog:"str"`

--- a/zenv/zenv.go
+++ b/zenv/zenv.go
@@ -18,7 +18,11 @@ type envDataProvider struct {
 }
 
 func (e *envDataProvider) Get(key string) any {
-	return strings.TrimSpace(os.Getenv(key))
+	val := strings.TrimSpace(os.Getenv(key))
+	if val == "" {
+		return nil
+	}
+	return val
 }
 
 func (e *envDataProvider) GetByField(field reflect.StructField, fallback string) (any, string) {

--- a/zenv/zenv_test.go
+++ b/zenv/zenv_test.go
@@ -82,7 +82,7 @@ func TestEnvDataProviderGet(t *testing.T) {
 
 	// Test with non-existent environment variable
 	result = provider.Get("NON_EXISTENT_VAR")
-	assert.Equal(t, "", result)
+	assert.Equal(t, nil, result)
 
 	// Test with environment variable containing whitespace
 	os.Setenv("WHITESPACE_VAR", "  trimmed  ")


### PR DESCRIPTION
Addresses #111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty and nil values across validation and parsing, ensuring more accurate error reporting and default value application.
  - Adjusted environment variable retrieval to return nil for unset or empty values instead of an empty string.

- **Tests**
  - Updated test cases to reflect new validation rules and error code checks, particularly for required fields and minimum string lengths.
  - Added a new test verifying correct handling of optional and required struct fields during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->