### PR TITLE
docs(i18n): fix maintainer handle for Japanese (ja) translation

### DIFF
--- a/docs/docs/packages/i18n.md
+++ b/docs/docs/packages/i18n.md
@@ -14,7 +14,7 @@ First Party Languages (maintained by Zog maintainers and guaranteed to be up to 
 Third Party Languages (community maintained, may lag behind):
 
 - `Azerbaijani` (by [@aykhans](https://github.com/aykhans))
-- `Japanese` (by [@sarada824](https://github.com/sarada824))
+- `Japanese` (by [@sawada-naoya](https://github.com/sawada-naoya))
 
 You can add your own custom languages or even make a package for a new language very easily. We encourage you to submit pull requests to update error message translations if you find any issues or want to contribute a new language.
 


### PR DESCRIPTION
Small follow-up to #181.

This PR fixes a typo in the docs for the Third Party Languages list:
- before: @sarada824
- after:  @sawada-naoya

No code changes, documentation only.