### PR TITLE
feat(i18n): add Japanese message for IP validator (IPv4)

### DIFF
--- a/i18n/ja/ja.go
+++ b/i18n/ja/ja.go
@@ -28,6 +28,7 @@ var Map zconst.LangMap = map[zconst.ZogType]map[zconst.ZogIssueCode]string{
 		zconst.IssueCodeUUID:                                 "有効なUUIDである必要があります",
 		zconst.IssueCodeMatch:                                "文字列が無効です",
 		zconst.IssueCodeURL:                                  "有効なURLである必要があります",
+		zconst.IssueCodeIP:                                   "有効な {{ip}} アドレスである必要があります",
 		zconst.IssueCodeHasPrefix:                            "文字列は {{prefix}} で始まる必要があります",
 		zconst.IssueCodeHasSuffix:                            "文字列は {{suffix}} で終わる必要があります",
 		zconst.IssueCodeContains:                             "文字列に {{contained}} を含める必要があります",


### PR DESCRIPTION
Follow-up to #194 

- Adds JA translation for the new IP validator message (mirrors EN key: IssueCodeIP with {{ip}} param)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Japanese language support for IP validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->