### PR TITLE
feat(i18n): add Azerbaijani message for IP validator

### DIFF
--- a/i18n/az/az.go
+++ b/i18n/az/az.go
@@ -28,6 +28,7 @@ var Map zconst.LangMap = map[zconst.ZogType]map[zconst.ZogIssueCode]string{
 		zconst.IssueCodeUUID:                                 "etibarlı UUID olmalıdır",
 		zconst.IssueCodeMatch:                                "sətir yanlışdır",
 		zconst.IssueCodeURL:                                  "etibarlı URL olmalıdır",
+		zconst.IssueCodeIP:                                   "etibarlı {{ip}} ünvanı olmalıdır",
 		zconst.IssueCodeHasPrefix:                            "sətir '{{prefix}}' ilə başlamalıdır",
 		zconst.IssueCodeHasSuffix:                            "sətir '{{suffix}}' ilə bitməlidir",
 		zconst.IssueCodeContains:                             "sətir daxilində '{{contained}}' olmalıdır",


### PR DESCRIPTION
Follow-up to #194 

Adds Azerbaijani translation for IP validator error message (`IssueCodeIP`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Azerbaijani language translation for IP-related validation messages, expanding localization coverage for users in that locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->