### PR TITLE
feat: add IPv6 and generic IP validators for strings

### DIFF
--- a/string.go
+++ b/string.go
@@ -244,6 +244,17 @@ func (v *StringSchema[T]) URL(options ...TestOption) *StringSchema[T] {
 	return v.addTest(t, fn, options...)
 }
 
+// Test: checks that the value is a valid IP address (IPv4 or IPv6)
+func (v *StringSchema[T]) IP(options ...TestOption) *StringSchema[T] {
+	t := p.Test[*T]{IssueCode: zconst.IssueCodeIP, Params: make(map[string]any, 1)}
+	t.Params[zconst.IssueCodeIP] = zconst.IP
+	fn := func(v *T, ctx Ctx) bool {
+		ip := net.ParseIP(string(*v))
+		return ip != nil
+	}
+	return v.addTest(t, fn, options...)
+}
+
 // Test: checks that the value is a valid IPv4 address
 func (v *StringSchema[T]) IPv4(options ...TestOption) *StringSchema[T] {
 	t := p.Test[*T]{IssueCode: zconst.IssueCodeIP, Params: make(map[string]any, 1)}
@@ -251,6 +262,17 @@ func (v *StringSchema[T]) IPv4(options ...TestOption) *StringSchema[T] {
 	fn := func(v *T, ctx Ctx) bool {
 		ip := net.ParseIP(string(*v))
 		return ip != nil && ip.To4() != nil && !strings.ContainsRune(string(*v), ':')
+	}
+	return v.addTest(t, fn, options...)
+}
+
+// Test: checks that the value is a valid IPv6 address
+func (v *StringSchema[T]) IPv6(options ...TestOption) *StringSchema[T] {
+	t := p.Test[*T]{IssueCode: zconst.IssueCodeIP, Params: make(map[string]any, 1)}
+	t.Params[zconst.IssueCodeIP] = zconst.IPv6
+	fn := func(v *T, ctx Ctx) bool {
+		ip := net.ParseIP(string(*v))
+		return ip != nil && ip.To4() == nil
 	}
 	return v.addTest(t, fn, options...)
 }

--- a/string_validate_test.go
+++ b/string_validate_test.go
@@ -207,6 +207,78 @@ func TestValidateStringURL(t *testing.T) {
 	assert.Equal(t, "http://example.com", dest)
 }
 
+func TestStringValidateIP(t *testing.T) {
+	field := String().IP()
+	var dest string
+
+	// Valid IPv4 cases
+	dest = "192.168.1.1"
+	errs := field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "127.0.0.1"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "255.255.255.255"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	// Valid IPv6 cases
+	dest = "2001:db8::1"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "::1"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "2001:0db8:0000:0000:0000:ff00:0042:8329"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "::ffff:192.168.1.1"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "fe80::1"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	// Empty string is valid for optional field
+	dest = ""
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	// Invalid cases
+	dest = "not-an-ip"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	dest = "256.1.1.1"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	dest = "192.168.1"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	dest = "gggg::1"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	// Required field with empty string
+	requiredField := String().Required().IP()
+	dest = ""
+	errs = requiredField.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeRequired, errs[0].Code)
+}
+
 func TestStringValidateIPv4(t *testing.T) {
 	field := String().IPv4()
 	var dest string
@@ -277,6 +349,71 @@ func TestStringValidateIPv4(t *testing.T) {
 
 	// Required field with empty string
 	requiredField := String().Required().IPv4()
+	dest = ""
+	errs = requiredField.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeRequired, errs[0].Code)
+}
+
+func TestStringValidateIPv6(t *testing.T) {
+	field := String().IPv6()
+	var dest string
+
+	// Valid IPv6 cases
+	dest = "2001:db8::1"
+	errs := field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "::1"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "2001:0db8:0000:0000:0000:ff00:0042:8329"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "fe80::1"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	dest = "2001:db8:85a3::8a2e:370:7334"
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	// Empty string is valid for optional field
+	dest = ""
+	errs = field.Validate(&dest)
+	assert.Empty(t, errs)
+
+	// Invalid cases - IPv4 addresses should fail IPv6 validation
+	dest = "192.168.1.1"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	dest = "127.0.0.1"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	// IPv6-mapped IPv4 addresses should fail pure IPv6 validation
+	dest = "::ffff:192.168.1.1"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	dest = "not-an-ip"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	dest = "256.1.1.1"
+	errs = field.Validate(&dest)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeIP, errs[0].Code)
+
+	// Required field with empty string
+	requiredField := String().Required().IPv6()
 	dest = ""
 	errs = requiredField.Validate(&dest)
 	assert.NotEmpty(t, errs)

--- a/zconst/consts.go
+++ b/zconst/consts.go
@@ -137,7 +137,9 @@ const (
 	IssueCodeIP ZogIssueCode = "ip"
 
 	// IP version constants
+	IP   = "IP"
 	IPv4 = "IPv4"
+	IPv6 = "IPv6"
 
 	// Deprecated: Use IssueCodeHasPrefix instead
 	ErrCodeHasPrefix   ZogErrCode   = "prefix"


### PR DESCRIPTION
## Description
This PR adds IPv6 and generic IP validation capabilities to complement the existing IPv4 validator, completing the IP validation suite for the zog library.

## Implementation Details
- IPv6 validator: accepts pure IPv6 addresses using `ip.To4() == nil` logic
- Generic IP validator: accepts both IPv4 and IPv6 formats using `net.ParseIP() != nil`
- Consistent error messages: Uses existing `{{ip}}` template placeholder
- Future-proof Design: Builds on the IPv4 validator foundation established in #192

## Testing
Comprehensive tests covering:
- Pure IPv6 addresses (`2001:db8::1, ::1`, etc.)
- IPv4 addresses in IPv6 validator (correctly rejected)
- IPv6-mapped IPv4 addresses (`::ffff:192.168.1.1`)
- Invalid IP formats and edge cases
- Required/optional field scenarios
- Error code validation

## Example Usage
IPv6 validator:
```
field := z.String().IPv6()
err := field.Validate("2001:db8::1") // Valid
err = field.Validate("192.168.1.1")  // Invalid (IPv4)
```

Generic IP validator:
```
field := z.String().IP()
err := field.Validate("192.168.1.1")       // Valid (IPv4)
err = field.Validate("2001:db8::1")        // Valid (IPv6)
err = field.Validate("::ffff:192.168.1.1") // Valid (IPv6-mapped IPv4)
```
Closes issue #197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IP address validation supporting both IPv4 and IPv6 formats.
  * Enhanced IPv4 validation with stricter format requirements for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->