### PR TITLE
fix(ctx): Clear values on ExecCtx when creating a new one

### DIFF
--- a/pkgs/internals/contexts.go
+++ b/pkgs/internals/contexts.go
@@ -47,6 +47,7 @@ func NewExecCtx(errs ZogIssues, fmter IssueFmtFunc) *ExecCtx {
 	c := ExecCtxPool.Get().(*ExecCtx)
 	c.Fmter = fmter
 	c.Errors = errs
+	c.m = map[string]any{}
 	return c
 }
 
@@ -65,9 +66,6 @@ func (c *ExecCtx) SetIssueFormatter(fmter IssueFmtFunc) {
 }
 
 func (c *ExecCtx) Set(key string, val any) {
-	if c.m == nil {
-		c.m = make(map[string]any)
-	}
 	c.m[key] = val
 }
 

--- a/pkgs/internals/contexts.go
+++ b/pkgs/internals/contexts.go
@@ -47,9 +47,7 @@ func NewExecCtx(errs ZogIssues, fmter IssueFmtFunc) *ExecCtx {
 	c := ExecCtxPool.Get().(*ExecCtx)
 	c.Fmter = fmter
 	c.Errors = errs
-	if c.m == nil {
-		c.m = map[string]any{}
-	} else {
+	if c.m != nil {
 		clear(c.m)
 	}
 	return c
@@ -70,6 +68,9 @@ func (c *ExecCtx) SetIssueFormatter(fmter IssueFmtFunc) {
 }
 
 func (c *ExecCtx) Set(key string, val any) {
+	if c.m == nil {
+		c.m = make(map[string]any)
+	}
 	c.m[key] = val
 }
 

--- a/pkgs/internals/contexts.go
+++ b/pkgs/internals/contexts.go
@@ -47,7 +47,11 @@ func NewExecCtx(errs ZogIssues, fmter IssueFmtFunc) *ExecCtx {
 	c := ExecCtxPool.Get().(*ExecCtx)
 	c.Fmter = fmter
 	c.Errors = errs
-	c.m = map[string]any{}
+	if c.m == nil {
+		c.m = map[string]any{}
+	} else {
+		clear(c.m)
+	}
 	return c
 }
 

--- a/utilsOptions_test.go
+++ b/utilsOptions_test.go
@@ -17,6 +17,22 @@ func TestWithCtxValue(t *testing.T) {
 	assert.Equal(t, "bar", ctx.Get("foo"))
 }
 
+func TestWithCtxValueNotPersistedAcrossExecCtxReuse(t *testing.T) {
+	ctx1 := p.NewExecCtx(nil, nil)
+	ctx1.Set("secret", "should_not_leak")
+	assert.Equal(t, "should_not_leak", ctx1.Get("secret"))
+	ctx1.Free()
+
+	// Proove that there is no longer a leak when pulling execution context out of
+	// the pool. Previously this would not erase the map of data stored on the
+	// context. It was possible to store a value on a context, free that context,
+	// then see that value appear on subsequent context usages elsewhere. This
+	// test should prove that that won't happen.
+	ctx2 := p.NewExecCtx(nil, nil)
+	assert.Nil(t, ctx2.Get("secret"))
+	ctx2.Free()
+}
+
 func TestWithIssueFormatter(t *testing.T) {
 	var ctx = p.NewExecCtx(p.NewErrsList(), nil)
 	WithIssueFormatter(func(e *p.ZogIssue, p Ctx) {

--- a/utilsOptions_test.go
+++ b/utilsOptions_test.go
@@ -23,7 +23,7 @@ func TestWithCtxValueNotPersistedAcrossExecCtxReuse(t *testing.T) {
 	assert.Equal(t, "should_not_leak", ctx1.Get("secret"))
 	ctx1.Free()
 
-	// Proove that there is no longer a leak when pulling execution context out of
+	// Prove that there is no longer a leak when pulling execution context out of
 	// the pool. Previously this would not erase the map of data stored on the
 	// context. It was possible to store a value on a context, free that context,
 	// then see that value appear on subsequent context usages elsewhere. This


### PR DESCRIPTION
When a new ExecCtx is created (or pulled from the pool) it was previously possible for values set on the context via `Set(...)` to persist between instances. You could call Set then the context would get freed, and if you called Get on a subsequent context usage elsewhere it was possible that it could have that data previously stored.

This makes sure that the data map is always reset when creating a new one to prevent data leaking between instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Execution contexts are now reliably reset when reused so values set in one context no longer persist into another, preventing cross-request data leakage.

* **Tests**
  * Added a unit test that verifies execution-context reuse does not carry over previously set values, ensuring cleaned state between uses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->