### PR TITLE
fix: Fixed issue with `,omitempty` suffix in json tag

### DIFF
--- a/parsers/zjson/parseJson_test.go
+++ b/parsers/zjson/parseJson_test.go
@@ -1,0 +1,26 @@
+package zjson
+
+import (
+	"strings"
+	"testing"
+
+	z "github.com/Oudwins/zog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeOmitEmpty(t *testing.T) {
+	type User struct {
+		Email string `json:"email,omitempty"`
+	}
+
+	schema := z.Struct(z.Shape{
+		"email": z.String().Required(),
+	})
+
+	body := strings.NewReader(`{"other":"x"}`)
+
+	var u User
+	errs := schema.Parse(Decode(body), &u)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, []string{"email"}, errs[0].Path)
+}

--- a/pkgs/internals/DataProviders.go
+++ b/pkgs/internals/DataProviders.go
@@ -3,6 +3,7 @@ package internals
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	zconst "github.com/Oudwins/zog/zconst"
 )
@@ -11,7 +12,10 @@ func GetKeyFromField(field reflect.StructField, fallback string, tag *string) st
 	if tag != nil {
 		fieldTag, ok := field.Tag.Lookup(*tag)
 		if ok {
-			return fieldTag
+			name, _, _ := strings.Cut(fieldTag, ",")
+			if name != "" {
+				return name
+			}
 		}
 	}
 	fieldTag, ok := field.Tag.Lookup(zconst.ZogTag)

--- a/zenv/zenv_test.go
+++ b/zenv/zenv_test.go
@@ -65,6 +65,25 @@ func TestEnvParsingWithConflictingTags(t *testing.T) {
 	os.Setenv("TEST_STR", "")
 }
 
+func TestEnvTagWithOptions(t *testing.T) {
+	type TestStruct struct {
+		Str  string `env:"TEST_STR,required"`
+		PORT int
+	}
+	env := TestStruct{}
+	schema := z.Struct(z.Shape{
+		"str":  z.String().Required(),
+		"PORT": z.Int().Default(8080),
+	})
+
+	os.Setenv("TEST_STR", "hello")
+	err := schema.Parse(NewDataProvider(), &env)
+	assert.Nil(t, err)
+	assert.Equal(t, "hello", env.Str)
+	assert.Equal(t, 8080, env.PORT)
+	os.Setenv("TEST_STR", "")
+}
+
 // Unit tests for envDataProvider
 func TestNewDataProvider(t *testing.T) {
 	provider := NewDataProvider()


### PR DESCRIPTION
When a struct you were parsing into had a field with a json tage like `name,omitempty`, it would not properly recognize this field as simply `name`.

This is a small tweak to cut the tag at the first comma (if there is one) in order to be consistent with how json and others handles these tags.

I didn't make the change for the `zog:` tag though as that doesn't seem to need it.

---

For example; on the current master branch:

```go
func TestDecodeOmitEmpty(t *testing.T) {
	type User struct {
		Email string `json:"email,omitempty"`
	}

	schema := z.Struct(z.Shape{
		"email": z.String().Required(),
	})

	body := strings.NewReader(`{"other":"x"}`)

	var u User
	errs := schema.Parse(Decode(body), &u)
	assert.NotEmpty(t, errs)
	assert.Equal(t, []string{"email"}, errs[0].Path)
}
```

Fails with the following output:

```
=== RUN   TestDecodeOmitEmpty
    parseJson_test.go:25: 
                Error Trace:    /home/elliotcourant/github/zog/parsers/zjson/parseJson_test.go:25
                Error:          Not equal: 
                                expected: []string{"email"}
                                actual  : []string{"email,omitempty"}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 ([]string) (len=1) {
                                - (string) (len=5) "email"
                                + (string) (len=15) "email,omitempty"
                                 }
                Test:           TestDecodeOmitEmpty
--- FAIL: TestDecodeOmitEmpty (0.00s)
FAIL
FAIL    github.com/Oudwins/zog/parsers/zjson    0.002s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tag parsing to correctly handle tag options in JSON and environment variable declarations. Tags with options (e.g., `omitempty`, `required`) are now properly processed.

* **Tests**
  * Enhanced test coverage for tag option parsing in JSON and environment variable validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->