### PR TITLE
feat!: Support nullable fields by default

### DIFF
--- a/pkgs/internals/DataProviders.go
+++ b/pkgs/internals/DataProviders.go
@@ -48,13 +48,30 @@ func (s *StructDataProvider) Get(key string) any {
 	// A nil pointer or interface field is the struct-input equivalent of an
 	// explicit null key. Emit the sentinel so Nullable() can act on it.
 	// Non-Nullable schemas still short-circuit via IsParseZeroValue.
-	switch field.Kind() {
-	case reflect.Pointer, reflect.Interface:
-		if field.IsNil() {
-			return ExplicitNullMarker
-		}
+	if isExplicitNullValue(field) {
+		return ExplicitNullMarker
 	}
 	return field.Interface()
+}
+
+// Reports whether a reflect.Value should be treated as an explicit null.
+// Covers nil pointer values and interface values holding a typed-nil pointer.
+// Non-pointer nillable kinds (slice/map/chan/func) are intentionally excluded:
+// a nil slice is not semantically an explicit null, and emitting the sentinel
+// for them would change behavior for non-Nullable schemas that currently
+// accept nil slices as empty input.
+func isExplicitNullValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Pointer:
+		return v.IsNil()
+	case reflect.Interface:
+		if v.IsNil() {
+			return true
+		}
+		inner := v.Elem()
+		return inner.Kind() == reflect.Pointer && inner.IsNil()
+	}
+	return false
 }
 
 func (s *StructDataProvider) GetByField(field reflect.StructField, fallback string) (any, string) {
@@ -89,6 +106,15 @@ func (m *MapDataProvider[T]) Get(key string) any {
 	// distinguish it from an absent key. Typed maps never reach this branch
 	// because any(v) == nil is false for non-interface T.
 	if any(v) == nil {
+		return ExplicitNullMarker
+	}
+	// MapDataProvider[any] may hold a typed-nil pointer (e.g. (*string)(nil))
+	// inside an otherwise non-nil interface. reflect sees through the interface
+	// to the concrete nil pointer; treat that as an explicit null too. Other
+	// nillable kinds (slice/map/chan/func) are intentionally not handled here:
+	// emitting the sentinel for a nil slice value would change behavior for
+	// existing non-Nullable schemas that accept nil slices as empty input.
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Pointer && rv.IsNil() {
 		return ExplicitNullMarker
 	}
 	return v

--- a/pkgs/internals/DataProviders.go
+++ b/pkgs/internals/DataProviders.go
@@ -45,36 +45,7 @@ func (s *StructDataProvider) Get(key string) any {
 	if !field.IsValid() {
 		return nil
 	}
-	// A nil pointer or interface field is the struct-input equivalent of an
-	// explicit null key. Emit the sentinel so pointer schemas can clear the
-	// destination. Non-pointer schemas still short-circuit via IsParseZeroValue.
-	if IsExplicitNullSource(field) {
-		return ExplicitNullMarker()
-	}
 	return field.Interface()
-}
-
-// IsExplicitNullSource reports whether a reflect.Value should be treated as an
-// explicit null source (a nil pointer, or an interface wrapping a typed-nil
-// pointer). Non-pointer nillable kinds (slice/map/chan/func) are intentionally
-// excluded: a nil slice is not semantically an explicit null, and emitting the
-// sentinel for them would change behavior for non-pointer schemas that
-// currently accept nil slices and maps as empty input.
-func IsExplicitNullSource(v reflect.Value) bool {
-	if !v.IsValid() {
-		return false
-	}
-	switch v.Kind() {
-	case reflect.Pointer:
-		return v.IsNil()
-	case reflect.Interface:
-		if v.IsNil() {
-			return true
-		}
-		inner := v.Elem()
-		return inner.Kind() == reflect.Pointer && inner.IsNil()
-	}
-	return false
 }
 
 func (s *StructDataProvider) GetByField(field reflect.StructField, fallback string) (any, string) {
@@ -105,18 +76,14 @@ func (m *MapDataProvider[T]) Get(key string) any {
 	if !ok {
 		return nil
 	}
-	// Present-with-nil emits the sentinel so pointer schemas can distinguish it
-	// from an absent key. Typed maps never reach this branch because
-	// any(v) == nil is false for non-interface T.
+	// Present with nil emits the sentinel so pointer schemas can distinguish it
+	// from an absent key.
 	if any(v) == nil {
 		return ExplicitNullMarker()
 	}
-	// MapDataProvider[any] may hold a typed-nil pointer (e.g. (*string)(nil))
-	// inside an otherwise non-nil interface. reflect sees through the interface
-	// to the concrete nil pointer; treat that as an explicit null too. Other
-	// nillable kinds (slice/map/chan/func) are intentionally not handled here:
-	// emitting the sentinel for a nil slice value would change behavior for
-	// existing non-pointer schemas that accept nil slices as empty input.
+	// A typed nil pointer inside an interface like (*string) is not == nil but is
+	// still semantically an explicit null. Other nillable kinds are excluded, a
+	// nil slice is accepted as empty input by non-pointer schemas today.
 	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Pointer && rv.IsNil() {
 		return ExplicitNullMarker()
 	}
@@ -180,13 +147,9 @@ func TryNewAnyDataProvider(val any) (DataProvider, error) {
 	if ok {
 		return dp, nil
 	}
-	// Sentinel must be handled before the reflect path. It is a non-nil pointer
-	// to a struct, so the Pointer/Struct cases below would wrap it as a
-	// StructDataProvider over ExplicitNull{}.
-	if IsExplicitNull(val) {
-		return &EmptyDataProvider{Underlying: val}, nil
-	}
-	if val == nil {
+	// Here we treat the sentinel and a nil (absence) as the same because we are
+	// at the top level, for individual fields we do a different behavior.
+	if IsExplicitNull(val) || val == nil {
 		return &EmptyDataProvider{Underlying: val}, nil
 	}
 	x := reflect.ValueOf(val)

--- a/pkgs/internals/DataProviders.go
+++ b/pkgs/internals/DataProviders.go
@@ -46,8 +46,8 @@ func (s *StructDataProvider) Get(key string) any {
 		return nil
 	}
 	// A nil pointer or interface field is the struct-input equivalent of an
-	// explicit null key. Emit the sentinel so Nullable() can act on it.
-	// Non-Nullable schemas still short-circuit via IsParseZeroValue.
+	// explicit null key. Emit the sentinel so pointer schemas can clear the
+	// destination. Non-pointer schemas still short-circuit via IsParseZeroValue.
 	if IsExplicitNullSource(field) {
 		return ExplicitNullMarker()
 	}
@@ -58,7 +58,7 @@ func (s *StructDataProvider) Get(key string) any {
 // explicit null source (a nil pointer, or an interface wrapping a typed-nil
 // pointer). Non-pointer nillable kinds (slice/map/chan/func) are intentionally
 // excluded: a nil slice is not semantically an explicit null, and emitting the
-// sentinel for them would change behavior for non-Nullable schemas that
+// sentinel for them would change behavior for non-pointer schemas that
 // currently accept nil slices and maps as empty input.
 func IsExplicitNullSource(v reflect.Value) bool {
 	if !v.IsValid() {
@@ -105,9 +105,9 @@ func (m *MapDataProvider[T]) Get(key string) any {
 	if !ok {
 		return nil
 	}
-	// Present-with-nil emits the sentinel so Nullable() pointer schemas can
-	// distinguish it from an absent key. Typed maps never reach this branch
-	// because any(v) == nil is false for non-interface T.
+	// Present-with-nil emits the sentinel so pointer schemas can distinguish it
+	// from an absent key. Typed maps never reach this branch because
+	// any(v) == nil is false for non-interface T.
 	if any(v) == nil {
 		return ExplicitNullMarker()
 	}
@@ -116,7 +116,7 @@ func (m *MapDataProvider[T]) Get(key string) any {
 	// to the concrete nil pointer; treat that as an explicit null too. Other
 	// nillable kinds (slice/map/chan/func) are intentionally not handled here:
 	// emitting the sentinel for a nil slice value would change behavior for
-	// existing non-Nullable schemas that accept nil slices as empty input.
+	// existing non-pointer schemas that accept nil slices as empty input.
 	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Pointer && rv.IsNil() {
 		return ExplicitNullMarker()
 	}

--- a/pkgs/internals/DataProviders.go
+++ b/pkgs/internals/DataProviders.go
@@ -45,6 +45,15 @@ func (s *StructDataProvider) Get(key string) any {
 	if !field.IsValid() {
 		return nil
 	}
+	// A nil pointer or interface field is the struct-input equivalent of an
+	// explicit null key. Emit the sentinel so Nullable() can act on it.
+	// Non-Nullable schemas still short-circuit via IsParseZeroValue.
+	switch field.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if field.IsNil() {
+			return ExplicitNullMarker
+		}
+	}
 	return field.Interface()
 }
 
@@ -75,6 +84,12 @@ func (m *MapDataProvider[T]) Get(key string) any {
 	v, ok := m.M[key]
 	if !ok {
 		return nil
+	}
+	// Present-with-nil emits the sentinel so Nullable() pointer schemas can
+	// distinguish it from an absent key. Typed maps never reach this branch
+	// because any(v) == nil is false for non-interface T.
+	if any(v) == nil {
+		return ExplicitNullMarker
 	}
 	return v
 }
@@ -135,6 +150,12 @@ func TryNewAnyDataProvider(val any) (DataProvider, error) {
 	dp, ok := val.(DataProvider)
 	if ok {
 		return dp, nil
+	}
+	// Sentinel must be handled before the reflect path. It is a non-nil pointer
+	// to a struct, so the Pointer/Struct cases below would wrap it as a
+	// StructDataProvider over ExplicitNull{}.
+	if IsExplicitNull(val) {
+		return &EmptyDataProvider{Underlying: val}, nil
 	}
 	if val == nil {
 		return &EmptyDataProvider{Underlying: val}, nil

--- a/pkgs/internals/DataProviders.go
+++ b/pkgs/internals/DataProviders.go
@@ -48,19 +48,22 @@ func (s *StructDataProvider) Get(key string) any {
 	// A nil pointer or interface field is the struct-input equivalent of an
 	// explicit null key. Emit the sentinel so Nullable() can act on it.
 	// Non-Nullable schemas still short-circuit via IsParseZeroValue.
-	if isExplicitNullValue(field) {
+	if IsExplicitNullSource(field) {
 		return ExplicitNullMarker
 	}
 	return field.Interface()
 }
 
-// Reports whether a reflect.Value should be treated as an explicit null.
-// Covers nil pointer values and interface values holding a typed-nil pointer.
-// Non-pointer nillable kinds (slice/map/chan/func) are intentionally excluded:
-// a nil slice is not semantically an explicit null, and emitting the sentinel
-// for them would change behavior for non-Nullable schemas that currently
-// accept nil slices as empty input.
-func isExplicitNullValue(v reflect.Value) bool {
+// IsExplicitNullSource reports whether a reflect.Value should be treated as an
+// explicit null source (a nil pointer, or an interface wrapping a typed-nil
+// pointer). Non-pointer nillable kinds (slice/map/chan/func) are intentionally
+// excluded: a nil slice is not semantically an explicit null, and emitting the
+// sentinel for them would change behavior for non-Nullable schemas that
+// currently accept nil slices and maps as empty input.
+func IsExplicitNullSource(v reflect.Value) bool {
+	if !v.IsValid() {
+		return false
+	}
 	switch v.Kind() {
 	case reflect.Pointer:
 		return v.IsNil()

--- a/pkgs/internals/DataProviders.go
+++ b/pkgs/internals/DataProviders.go
@@ -49,7 +49,7 @@ func (s *StructDataProvider) Get(key string) any {
 	// explicit null key. Emit the sentinel so Nullable() can act on it.
 	// Non-Nullable schemas still short-circuit via IsParseZeroValue.
 	if IsExplicitNullSource(field) {
-		return ExplicitNullMarker
+		return ExplicitNullMarker()
 	}
 	return field.Interface()
 }
@@ -109,7 +109,7 @@ func (m *MapDataProvider[T]) Get(key string) any {
 	// distinguish it from an absent key. Typed maps never reach this branch
 	// because any(v) == nil is false for non-interface T.
 	if any(v) == nil {
-		return ExplicitNullMarker
+		return ExplicitNullMarker()
 	}
 	// MapDataProvider[any] may hold a typed-nil pointer (e.g. (*string)(nil))
 	// inside an otherwise non-nil interface. reflect sees through the interface
@@ -118,7 +118,7 @@ func (m *MapDataProvider[T]) Get(key string) any {
 	// emitting the sentinel for a nil slice value would change behavior for
 	// existing non-Nullable schemas that accept nil slices as empty input.
 	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Pointer && rv.IsNil() {
-		return ExplicitNullMarker
+		return ExplicitNullMarker()
 	}
 	return v
 }

--- a/pkgs/internals/zeroValues.go
+++ b/pkgs/internals/zeroValues.go
@@ -14,5 +14,20 @@ func IsZeroValue(x any) bool {
 
 // checks if the value is the zero value but only for parsing purposes (i.e the parse function)
 func IsParseZeroValue(val any, ctx Ctx) bool {
-	return val == nil
+	if val == nil {
+		return true
+	}
+	return IsExplicitNull(val)
+}
+
+// ExplicitNull is a sentinel for "key present with nil value" (e.g. JSON null)
+// as opposed to "key absent". MapDataProvider.Get collapses both to bare nil
+// without it, so PointerSchema.Nullable() has nothing to act on.
+type ExplicitNull struct{}
+
+var ExplicitNullMarker = &ExplicitNull{}
+
+func IsExplicitNull(val any) bool {
+	_, ok := val.(*ExplicitNull)
+	return ok
 }

--- a/pkgs/internals/zeroValues.go
+++ b/pkgs/internals/zeroValues.go
@@ -25,7 +25,16 @@ func IsParseZeroValue(val any, ctx Ctx) bool {
 // without it, so PointerSchema.Nullable() has nothing to act on.
 type ExplicitNull struct{}
 
-var ExplicitNullMarker = &ExplicitNull{}
+// Unexported so external code cannot reassign or nil it out. Detection is
+// type-based via IsExplicitNull, so any *ExplicitNull instance would still
+// match, but emission paths need a stable singleton to return.
+var explicitNullMarker = &ExplicitNull{}
+
+// ExplicitNullMarker returns the canonical sentinel instance for emission sites
+// that need to signal "present with nil value" to downstream schemas.
+func ExplicitNullMarker() *ExplicitNull {
+	return explicitNullMarker
+}
 
 func IsExplicitNull(val any) bool {
 	_, ok := val.(*ExplicitNull)

--- a/pkgs/internals/zeroValues.go
+++ b/pkgs/internals/zeroValues.go
@@ -25,13 +25,9 @@ func IsParseZeroValue(val any, ctx Ctx) bool {
 // without it, so pointer schemas cannot distinguish the two cases.
 type ExplicitNull struct{}
 
-// Unexported so external code cannot reassign or nil it out. Detection is
-// type-based via IsExplicitNull, so any *ExplicitNull instance would still
-// match, but emission paths need a stable singleton to return.
+// Unexported so external packages cannot reassign the singleton.
 var explicitNullMarker = &ExplicitNull{}
 
-// ExplicitNullMarker returns the canonical sentinel instance for emission sites
-// that need to signal "present with nil value" to downstream schemas.
 func ExplicitNullMarker() *ExplicitNull {
 	return explicitNullMarker
 }

--- a/pkgs/internals/zeroValues.go
+++ b/pkgs/internals/zeroValues.go
@@ -22,7 +22,7 @@ func IsParseZeroValue(val any, ctx Ctx) bool {
 
 // ExplicitNull is a sentinel for "key present with nil value" (e.g. JSON null)
 // as opposed to "key absent". MapDataProvider.Get collapses both to bare nil
-// without it, so PointerSchema.Nullable() has nothing to act on.
+// without it, so pointer schemas cannot distinguish the two cases.
 type ExplicitNull struct{}
 
 // Unexported so external code cannot reassign or nil it out. Detection is

--- a/pointers.go
+++ b/pointers.go
@@ -13,7 +13,6 @@ var _ ComplexZogSchema = &PointerSchema{}
 type PointerSchema struct {
 	schema   ZogSchema
 	required *p.Test[any]
-	nullable bool
 	// postTransforms []PostTransform
 	// defaultVal     *any
 	// catch          *any
@@ -68,9 +67,9 @@ func (v *PointerSchema) process(ctx *p.SchemaCtx) {
 		ctx.Data = val
 	}
 
-	// Nullable clears the destination on explicit null. NotNil cannot be set here
-	// because Nullable and NotNil clear each other.
-	if v.nullable && p.IsExplicitNull(ctx.Data) {
+	// Explicit null in the input clears the destination pointer. NotNil opts
+	// out of clearing and falls through to the required-error path below.
+	if p.IsExplicitNull(ctx.Data) && v.required == nil {
 		rv := reflect.ValueOf(ctx.ValPtr)
 		destPtr := rv.Elem()
 		destPtr.Set(reflect.Zero(destPtr.Type()))
@@ -148,17 +147,5 @@ func (v *PointerSchema) NotNil(options ...TestOption) *PointerSchema {
 		opt(&r)
 	}
 	v.required = &r
-	v.nullable = false
-	return v
-}
-
-// Nullable makes the pointer schema treat explicit null input (e.g. JSON
-// null) as a request to clear the destination pointer. An absent key still
-// preserves the destination; only an explicit null clears it. Last-writer
-// wins against NotNil: calling Nullable clears a prior NotNil requirement,
-// and calling NotNil afterwards clears Nullable.
-func (v *PointerSchema) Nullable() *PointerSchema {
-	v.nullable = true
-	v.required = nil
 	return v
 }

--- a/pointers.go
+++ b/pointers.go
@@ -13,6 +13,7 @@ var _ ComplexZogSchema = &PointerSchema{}
 type PointerSchema struct {
 	schema   ZogSchema
 	required *p.Test[any]
+	nullable bool
 	// postTransforms []PostTransform
 	// defaultVal     *any
 	// catch          *any
@@ -66,6 +67,16 @@ func (v *PointerSchema) process(ctx *p.SchemaCtx) {
 		}
 		ctx.Data = val
 	}
+
+	// Nullable clears the destination on explicit null. NotNil cannot be set here
+	// because Nullable and NotNil clear each other.
+	if v.nullable && p.IsExplicitNull(ctx.Data) {
+		rv := reflect.ValueOf(ctx.ValPtr)
+		destPtr := rv.Elem()
+		destPtr.Set(reflect.Zero(destPtr.Type()))
+		return
+	}
+
 	_, isEmptyStruct := ctx.Data.(*p.EmptyDataProvider)
 	// End of messy code
 
@@ -73,7 +84,13 @@ func (v *PointerSchema) process(ctx *p.SchemaCtx) {
 	if isZero {
 		if v.required != nil {
 			// We set the destination type to the schema type because pointer doesn't have any issue messages. They pass through to the schema type
-			ctx.AddIssue(ctx.IssueFromTest(v.required, ctx.Data).SetDType(v.schema.getType()))
+			issueVal := ctx.Data
+			if p.IsExplicitNull(issueVal) {
+				// Observable user intent is nil; keep the internal sentinel out of
+				// issues.
+				issueVal = nil
+			}
+			ctx.AddIssue(ctx.IssueFromTest(v.required, issueVal).SetDType(v.schema.getType()))
 		}
 		return
 	}
@@ -131,5 +148,17 @@ func (v *PointerSchema) NotNil(options ...TestOption) *PointerSchema {
 		opt(&r)
 	}
 	v.required = &r
+	v.nullable = false
+	return v
+}
+
+// Nullable makes the pointer schema treat explicit null input (e.g. JSON
+// null) as a request to clear the destination pointer. An absent key still
+// preserves the destination; only an explicit null clears it. Last-writer
+// wins against NotNil: calling Nullable clears a prior NotNil requirement,
+// and calling NotNil afterwards clears Nullable.
+func (v *PointerSchema) Nullable() *PointerSchema {
+	v.nullable = true
+	v.required = nil
 	return v
 }

--- a/pointers.go
+++ b/pointers.go
@@ -67,15 +67,6 @@ func (v *PointerSchema) process(ctx *p.SchemaCtx) {
 		ctx.Data = val
 	}
 
-	// Explicit null in the input clears the destination pointer. NotNil opts
-	// out of clearing and falls through to the required-error path below.
-	if p.IsExplicitNull(ctx.Data) && v.required == nil {
-		rv := reflect.ValueOf(ctx.ValPtr)
-		destPtr := rv.Elem()
-		destPtr.Set(reflect.Zero(destPtr.Type()))
-		return
-	}
-
 	_, isEmptyStruct := ctx.Data.(*p.EmptyDataProvider)
 	// End of messy code
 
@@ -85,11 +76,18 @@ func (v *PointerSchema) process(ctx *p.SchemaCtx) {
 			// We set the destination type to the schema type because pointer doesn't have any issue messages. They pass through to the schema type
 			issueVal := ctx.Data
 			if p.IsExplicitNull(issueVal) {
-				// Observable user intent is nil; keep the internal sentinel out of
-				// issues.
+				// Sentinel is internal surface nil to callers.
 				issueVal = nil
 			}
 			ctx.AddIssue(ctx.IssueFromTest(v.required, issueVal).SetDType(v.schema.getType()))
+			return
+		}
+		// Explicit null clears the destination pointer bare nil is treated as "key
+		// absent" and leaves the existing value in place.
+		if p.IsExplicitNull(ctx.Data) {
+			rv := reflect.ValueOf(ctx.ValPtr)
+			destPtr := rv.Elem()
+			destPtr.Set(reflect.Zero(destPtr.Type()))
 		}
 		return
 	}

--- a/pointers_nullable_test.go
+++ b/pointers_nullable_test.go
@@ -116,22 +116,6 @@ func TestPtrNullable_SliceOfNullablePtr(t *testing.T) {
 	assert.Equal(t, "c", *out[2])
 }
 
-func TestPtrNullable_StructInput_NilFieldClears(t *testing.T) {
-	// Shape key must match the Go field name for struct-to-struct parsing
-	// because StructDataProvider.Get uses FieldByName on the resolved key.
-	type Req struct {
-		Tag *string
-	}
-	schema := Struct(Shape{
-		"Tag": Ptr(String()),
-	})
-	src := Req{Tag: nil}
-	dst := Req{Tag: nullableStrPtr("clear-me")}
-	errs := schema.Parse(src, &dst)
-	assert.Empty(t, errs)
-	assert.Nil(t, dst.Tag)
-}
-
 func TestPtrNullable_TopLevelBareNilDoesNotClear(t *testing.T) {
 	schema := Ptr(String())
 	dest := nullableStrPtr("keep")
@@ -191,14 +175,3 @@ func TestPtrNullable_TypedNilInMapAnyValue_ClearsPointer(t *testing.T) {
 	assert.Empty(t, errs)
 	assert.Nil(t, out.Tag)
 }
-
-func TestPtrNullable_TypedNilInInterfaceStructField_EmitsSentinel(t *testing.T) {
-	type Req struct {
-		Thing any
-	}
-	src := Req{Thing: (*string)(nil)}
-	dp, err := p.TryNewAnyDataProvider(src)
-	assert.NoError(t, err)
-	assert.True(t, p.IsExplicitNull(dp.Get("Thing")))
-}
-

--- a/pointers_nullable_test.go
+++ b/pointers_nullable_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	p "github.com/Oudwins/zog/pkgs/internals"
-	"github.com/Oudwins/zog/zconst"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +14,7 @@ func TestPtrNullable_AbsentKeyPreservesExistingValue(t *testing.T) {
 		Tag *string
 	}
 	schema := Struct(Shape{
-		"tag": Ptr(String()).Nullable(),
+		"tag": Ptr(String()),
 	})
 	out := Req{Tag: nullableStrPtr("keep-me")}
 	errs := schema.Parse(map[string]any{}, &out)
@@ -29,7 +28,7 @@ func TestPtrNullable_ExplicitNullClearsPointer(t *testing.T) {
 		Tag *string
 	}
 	schema := Struct(Shape{
-		"tag": Ptr(String()).Nullable(),
+		"tag": Ptr(String()),
 	})
 	out := Req{Tag: nullableStrPtr("clear-me")}
 	errs := schema.Parse(map[string]any{"tag": nil}, &out)
@@ -42,55 +41,13 @@ func TestPtrNullable_ConcreteValueOverwrites(t *testing.T) {
 		Tag *string
 	}
 	schema := Struct(Shape{
-		"tag": Ptr(String()).Nullable(),
+		"tag": Ptr(String()),
 	})
 	var out Req
 	errs := schema.Parse(map[string]any{"tag": "v"}, &out)
 	assert.Empty(t, errs)
 	assert.NotNil(t, out.Tag)
 	assert.Equal(t, "v", *out.Tag)
-}
-
-func TestPtrNullable_WithoutOptIn_ExplicitNullPreserves(t *testing.T) {
-	type Req struct {
-		Tag *string
-	}
-	schema := Struct(Shape{
-		"tag": Ptr(String()),
-	})
-	out := Req{Tag: nullableStrPtr("keep-me")}
-	errs := schema.Parse(map[string]any{"tag": nil}, &out)
-	assert.Empty(t, errs)
-	assert.NotNil(t, out.Tag)
-	assert.Equal(t, "keep-me", *out.Tag)
-}
-
-func TestPtrNullable_NotNilAfterNullable_NotNilWins(t *testing.T) {
-	type Req struct {
-		Tag *string
-	}
-	schema := Struct(Shape{
-		"tag": Ptr(String()).Nullable().NotNil(),
-	})
-	out := Req{Tag: nullableStrPtr("keep-me")}
-	errs := schema.Parse(map[string]any{"tag": nil}, &out)
-	assert.NotEmpty(t, errs)
-	assert.Equal(t, zconst.IssueCodeNotNil, errs[0].Code)
-	assert.NotNil(t, out.Tag)
-	assert.Equal(t, "keep-me", *out.Tag)
-}
-
-func TestPtrNullable_NullableAfterNotNil_NullableWins(t *testing.T) {
-	type Req struct {
-		Tag *string
-	}
-	schema := Struct(Shape{
-		"tag": Ptr(String()).NotNil().Nullable(),
-	})
-	out := Req{Tag: nullableStrPtr("clear-me")}
-	errs := schema.Parse(map[string]any{"tag": nil}, &out)
-	assert.Empty(t, errs)
-	assert.Nil(t, out.Tag)
 }
 
 func TestPtrNullable_NestedStructPointer_NullClearsOuter(t *testing.T) {
@@ -103,7 +60,7 @@ func TestPtrNullable_NestedStructPointer_NullClearsOuter(t *testing.T) {
 	schema := Struct(Shape{
 		"inner": Ptr(Struct(Shape{
 			"v": Int(),
-		})).Nullable(),
+		})),
 	})
 	out := Outer{Inner: &Inner{V: 42}}
 	errs := schema.Parse(map[string]any{"inner": nil}, &out)
@@ -136,7 +93,7 @@ func TestPtrNullable_DoublePointer_OuterNullable(t *testing.T) {
 		V **string
 	}
 	schema := Struct(Shape{
-		"v": Ptr(Ptr(String())).Nullable(),
+		"v": Ptr(Ptr(String())),
 	})
 	inner := "keep"
 	outer := &inner
@@ -147,7 +104,7 @@ func TestPtrNullable_DoublePointer_OuterNullable(t *testing.T) {
 }
 
 func TestPtrNullable_SliceOfNullablePtr(t *testing.T) {
-	schema := Slice(Ptr(String()).Nullable())
+	schema := Slice(Ptr(String()))
 	var out []*string
 	errs := schema.Parse([]any{"a", nil, "c"}, &out)
 	assert.Empty(t, errs)
@@ -166,7 +123,7 @@ func TestPtrNullable_StructInput_NilFieldClears(t *testing.T) {
 		Tag *string
 	}
 	schema := Struct(Shape{
-		"Tag": Ptr(String()).Nullable(),
+		"Tag": Ptr(String()),
 	})
 	src := Req{Tag: nil}
 	dst := Req{Tag: nullableStrPtr("clear-me")}
@@ -176,7 +133,7 @@ func TestPtrNullable_StructInput_NilFieldClears(t *testing.T) {
 }
 
 func TestPtrNullable_TopLevelBareNilDoesNotClear(t *testing.T) {
-	schema := Ptr(String()).Nullable()
+	schema := Ptr(String())
 	dest := nullableStrPtr("keep")
 	errs := schema.Parse(nil, &dest)
 	assert.Empty(t, errs)
@@ -225,7 +182,7 @@ func TestPtrNullable_TypedNilInMapAnyValue_ClearsPointer(t *testing.T) {
 		Tag *string
 	}
 	schema := Struct(Shape{
-		"tag": Ptr(String()).Nullable(),
+		"tag": Ptr(String()),
 	})
 	var typedNil *string
 	input := map[string]any{"tag": typedNil}
@@ -245,34 +202,3 @@ func TestPtrNullable_TypedNilInInterfaceStructField_EmitsSentinel(t *testing.T) 
 	assert.True(t, p.IsExplicitNull(dp.Get("Thing")))
 }
 
-func TestPtrNullable_SliceOfNullablePtr_TypedNilInInterfaceElementClears(t *testing.T) {
-	// []any element containing a typed-nil pointer: the Interface case of
-	// IsExplicitNullSource unwraps and emits the sentinel, Nullable clears.
-	schema := Slice(Ptr(String()).Nullable())
-	var out []*string
-	var typedNil *string
-	input := []any{"a", typedNil, "c"}
-	errs := schema.Parse(input, &out)
-	assert.Empty(t, errs)
-	assert.Len(t, out, 3)
-	assert.NotNil(t, out[0])
-	assert.Equal(t, "a", *out[0])
-	assert.Nil(t, out[1])
-	assert.NotNil(t, out[2])
-	assert.Equal(t, "c", *out[2])
-}
-
-func TestPtrNullable_SliceOfNullablePtr_DirectTypedNilElementEmitsSentinel(t *testing.T) {
-	// Direct typed slice []*string{nil}: the Pointer case of IsExplicitNullSource
-	// detects the nil pointer element and emits the sentinel. Non-nil elements in
-	// a typed pointer slice still do not parse cleanly into their inner schema
-	// value because zog's coercion pipeline doesn't dereference typed pointers,
-	// so we scope this test to the nil element behavior only.
-	schema := Slice(Ptr(String()).Nullable())
-	var out []*string
-	input := []*string{nil}
-	errs := schema.Parse(input, &out)
-	assert.Empty(t, errs)
-	assert.Len(t, out, 1)
-	assert.Nil(t, out[0])
-}

--- a/pointers_nullable_test.go
+++ b/pointers_nullable_test.go
@@ -213,3 +213,34 @@ func TestPtrNullable_MapDataProvider_TypedMap_NoSentinel(t *testing.T) {
 	assert.False(t, p.IsExplicitNull(dp.Get("empty")))
 	assert.False(t, p.IsExplicitNull(dp.Get("missing")))
 }
+
+func TestPtrNullable_TypedNilInMapAnyValue_EmitsSentinel(t *testing.T) {
+	var typedNil *string
+	dp := p.NewSafeMapDataProvider(map[string]any{"tag": typedNil})
+	assert.True(t, p.IsExplicitNull(dp.Get("tag")))
+}
+
+func TestPtrNullable_TypedNilInMapAnyValue_ClearsPointer(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()).Nullable(),
+	})
+	var typedNil *string
+	input := map[string]any{"tag": typedNil}
+	out := Req{Tag: nullableStrPtr("preexisting")}
+	errs := schema.Parse(input, &out)
+	assert.Empty(t, errs)
+	assert.Nil(t, out.Tag)
+}
+
+func TestPtrNullable_TypedNilInInterfaceStructField_EmitsSentinel(t *testing.T) {
+	type Req struct {
+		Thing any
+	}
+	src := Req{Thing: (*string)(nil)}
+	dp, err := p.TryNewAnyDataProvider(src)
+	assert.NoError(t, err)
+	assert.True(t, p.IsExplicitNull(dp.Get("Thing")))
+}

--- a/pointers_nullable_test.go
+++ b/pointers_nullable_test.go
@@ -244,3 +244,35 @@ func TestPtrNullable_TypedNilInInterfaceStructField_EmitsSentinel(t *testing.T) 
 	assert.NoError(t, err)
 	assert.True(t, p.IsExplicitNull(dp.Get("Thing")))
 }
+
+func TestPtrNullable_SliceOfNullablePtr_TypedNilInInterfaceElementClears(t *testing.T) {
+	// []any element containing a typed-nil pointer: the Interface case of
+	// IsExplicitNullSource unwraps and emits the sentinel, Nullable clears.
+	schema := Slice(Ptr(String()).Nullable())
+	var out []*string
+	var typedNil *string
+	input := []any{"a", typedNil, "c"}
+	errs := schema.Parse(input, &out)
+	assert.Empty(t, errs)
+	assert.Len(t, out, 3)
+	assert.NotNil(t, out[0])
+	assert.Equal(t, "a", *out[0])
+	assert.Nil(t, out[1])
+	assert.NotNil(t, out[2])
+	assert.Equal(t, "c", *out[2])
+}
+
+func TestPtrNullable_SliceOfNullablePtr_DirectTypedNilElementEmitsSentinel(t *testing.T) {
+	// Direct typed slice []*string{nil}: the Pointer case of IsExplicitNullSource
+	// detects the nil pointer element and emits the sentinel. Non-nil elements in
+	// a typed pointer slice still do not parse cleanly into their inner schema
+	// value because zog's coercion pipeline doesn't dereference typed pointers,
+	// so we scope this test to the nil element behavior only.
+	schema := Slice(Ptr(String()).Nullable())
+	var out []*string
+	input := []*string{nil}
+	errs := schema.Parse(input, &out)
+	assert.Empty(t, errs)
+	assert.Len(t, out, 1)
+	assert.Nil(t, out[0])
+}

--- a/pointers_nullable_test.go
+++ b/pointers_nullable_test.go
@@ -1,0 +1,215 @@
+package zog
+
+import (
+	"testing"
+
+	p "github.com/Oudwins/zog/pkgs/internals"
+	"github.com/Oudwins/zog/zconst"
+	"github.com/stretchr/testify/assert"
+)
+
+func nullableStrPtr(s string) *string { return &s }
+
+func TestPtrNullable_AbsentKeyPreservesExistingValue(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()).Nullable(),
+	})
+	out := Req{Tag: nullableStrPtr("keep-me")}
+	errs := schema.Parse(map[string]any{}, &out)
+	assert.Empty(t, errs)
+	assert.NotNil(t, out.Tag)
+	assert.Equal(t, "keep-me", *out.Tag)
+}
+
+func TestPtrNullable_ExplicitNullClearsPointer(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()).Nullable(),
+	})
+	out := Req{Tag: nullableStrPtr("clear-me")}
+	errs := schema.Parse(map[string]any{"tag": nil}, &out)
+	assert.Empty(t, errs)
+	assert.Nil(t, out.Tag)
+}
+
+func TestPtrNullable_ConcreteValueOverwrites(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()).Nullable(),
+	})
+	var out Req
+	errs := schema.Parse(map[string]any{"tag": "v"}, &out)
+	assert.Empty(t, errs)
+	assert.NotNil(t, out.Tag)
+	assert.Equal(t, "v", *out.Tag)
+}
+
+func TestPtrNullable_WithoutOptIn_ExplicitNullPreserves(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()),
+	})
+	out := Req{Tag: nullableStrPtr("keep-me")}
+	errs := schema.Parse(map[string]any{"tag": nil}, &out)
+	assert.Empty(t, errs)
+	assert.NotNil(t, out.Tag)
+	assert.Equal(t, "keep-me", *out.Tag)
+}
+
+func TestPtrNullable_NotNilAfterNullable_NotNilWins(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()).Nullable().NotNil(),
+	})
+	out := Req{Tag: nullableStrPtr("keep-me")}
+	errs := schema.Parse(map[string]any{"tag": nil}, &out)
+	assert.NotEmpty(t, errs)
+	assert.Equal(t, zconst.IssueCodeNotNil, errs[0].Code)
+	assert.NotNil(t, out.Tag)
+	assert.Equal(t, "keep-me", *out.Tag)
+}
+
+func TestPtrNullable_NullableAfterNotNil_NullableWins(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()).NotNil().Nullable(),
+	})
+	out := Req{Tag: nullableStrPtr("clear-me")}
+	errs := schema.Parse(map[string]any{"tag": nil}, &out)
+	assert.Empty(t, errs)
+	assert.Nil(t, out.Tag)
+}
+
+func TestPtrNullable_NestedStructPointer_NullClearsOuter(t *testing.T) {
+	type Inner struct {
+		V int
+	}
+	type Outer struct {
+		Inner *Inner
+	}
+	schema := Struct(Shape{
+		"inner": Ptr(Struct(Shape{
+			"v": Int(),
+		})).Nullable(),
+	})
+	out := Outer{Inner: &Inner{V: 42}}
+	errs := schema.Parse(map[string]any{"inner": nil}, &out)
+	assert.Empty(t, errs)
+	assert.Nil(t, out.Inner)
+}
+
+func TestPtrNullable_NestedBareStruct_NullBehavesAsEmpty(t *testing.T) {
+	type Inner struct {
+		V *int
+	}
+	type Outer struct {
+		Inner Inner
+	}
+	schema := Struct(Shape{
+		"inner": Struct(Shape{
+			"v": Ptr(Int()),
+		}),
+	})
+	v := 7
+	out := Outer{Inner: Inner{V: &v}}
+	errs := schema.Parse(map[string]any{"inner": nil}, &out)
+	assert.Empty(t, errs)
+	assert.NotNil(t, out.Inner.V)
+	assert.Equal(t, 7, *out.Inner.V)
+}
+
+func TestPtrNullable_DoublePointer_OuterNullable(t *testing.T) {
+	type Req struct {
+		V **string
+	}
+	schema := Struct(Shape{
+		"v": Ptr(Ptr(String())).Nullable(),
+	})
+	inner := "keep"
+	outer := &inner
+	out := Req{V: &outer}
+	errs := schema.Parse(map[string]any{"v": nil}, &out)
+	assert.Empty(t, errs)
+	assert.Nil(t, out.V)
+}
+
+func TestPtrNullable_SliceOfNullablePtr(t *testing.T) {
+	schema := Slice(Ptr(String()).Nullable())
+	var out []*string
+	errs := schema.Parse([]any{"a", nil, "c"}, &out)
+	assert.Empty(t, errs)
+	assert.Len(t, out, 3)
+	assert.NotNil(t, out[0])
+	assert.Equal(t, "a", *out[0])
+	assert.Nil(t, out[1])
+	assert.NotNil(t, out[2])
+	assert.Equal(t, "c", *out[2])
+}
+
+func TestPtrNullable_StructInput_NilFieldClears(t *testing.T) {
+	// Shape key must match the Go field name for struct-to-struct parsing
+	// because StructDataProvider.Get uses FieldByName on the resolved key.
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"Tag": Ptr(String()).Nullable(),
+	})
+	src := Req{Tag: nil}
+	dst := Req{Tag: nullableStrPtr("clear-me")}
+	errs := schema.Parse(src, &dst)
+	assert.Empty(t, errs)
+	assert.Nil(t, dst.Tag)
+}
+
+func TestPtrNullable_TopLevelBareNilDoesNotClear(t *testing.T) {
+	schema := Ptr(String()).Nullable()
+	dest := nullableStrPtr("keep")
+	errs := schema.Parse(nil, &dest)
+	assert.Empty(t, errs)
+	assert.NotNil(t, dest)
+	assert.Equal(t, "keep", *dest)
+}
+
+func TestPtrNullable_IssueValueIsNotSentinel(t *testing.T) {
+	type Req struct {
+		Tag *string
+	}
+	schema := Struct(Shape{
+		"tag": Ptr(String()).NotNil(),
+	})
+	var out Req
+	errs := schema.Parse(map[string]any{"tag": nil}, &out)
+	assert.NotEmpty(t, errs)
+	assert.False(t, p.IsExplicitNull(errs[0].Value), "issue value must not be the internal sentinel")
+}
+
+func TestPtrNullable_MapDataProvider_EmitsSentinelForExplicitNull(t *testing.T) {
+	m := map[string]any{"present_null": nil, "present_val": "hello"}
+	dp := p.NewSafeMapDataProvider(m)
+	assert.Nil(t, dp.Get("absent_key"))
+	assert.True(t, p.IsExplicitNull(dp.Get("present_null")))
+	assert.Equal(t, "hello", dp.Get("present_val"))
+}
+
+func TestPtrNullable_MapDataProvider_TypedMap_NoSentinel(t *testing.T) {
+	m := map[string]string{"empty": ""}
+	dp := p.NewSafeMapDataProvider(m)
+	assert.Equal(t, "", dp.Get("empty"))
+	assert.Nil(t, dp.Get("missing"))
+	assert.False(t, p.IsExplicitNull(dp.Get("empty")))
+	assert.False(t, p.IsExplicitNull(dp.Get("missing")))
+}

--- a/slices.go
+++ b/slices.go
@@ -164,15 +164,20 @@ func (v *SliceSchema) process(ctx *p.SchemaCtx) {
 	subCtx := ctx.NewSchemaCtx(ctx.Data, ctx.ValPtr, ctx.Path, v.schema.getType())
 	defer subCtx.Free()
 	for idx := 0; idx < refVal.Len(); idx++ {
-		item := refVal.Index(idx).Interface()
-		// Untyped-nil slice elements map to the sentinel so Nullable() pointer
-		// schemas can clear the slot. Non-Nullable schemas treat the sentinel as
-		// zero via IsParseZeroValue. Typed-nil elements in typed slices (e.g.
-		// []*string{nil}) are intentionally not caught here: detecting them
-		// requires a reflect-based IsNil check per element, and the primary
-		// JSON decode path produces []any, not typed slices.
-		if item == nil {
+		elem := refVal.Index(idx)
+		// Nil pointer elements (both untyped []any{..., nil} and typed
+		// []*T{..., nil}) and interface elements wrapping a typed-nil pointer map
+		// to the sentinel so Nullable() pointer schemas can clear the slot.
+		// Non-Nullable schemas treat the sentinel as zero via IsParseZeroValue.
+		// Non-pointer nillable kinds (slice/map/chan/func) are not caught here on
+		// purpose: a nil sub-slice is not semantically explicit null and emitting
+		// the sentinel would change behavior for non-Nullable schemas that
+		// currently accept nil slices and maps as empty input.
+		var item any
+		if p.IsExplicitNullSource(elem) {
 			item = p.ExplicitNullMarker
+		} else {
+			item = elem.Interface()
 		}
 		ptr := destVal.Index(idx).Addr().Interface()
 		k := fmt.Sprintf("[%d]", idx)

--- a/slices.go
+++ b/slices.go
@@ -167,7 +167,10 @@ func (v *SliceSchema) process(ctx *p.SchemaCtx) {
 		item := refVal.Index(idx).Interface()
 		// Untyped-nil slice elements map to the sentinel so Nullable() pointer
 		// schemas can clear the slot. Non-Nullable schemas treat the sentinel as
-		// zero via IsParseZeroValue.
+		// zero via IsParseZeroValue. Typed-nil elements in typed slices (e.g.
+		// []*string{nil}) are intentionally not caught here: detecting them
+		// requires a reflect-based IsNil check per element, and the primary
+		// JSON decode path produces []any, not typed slices.
 		if item == nil {
 			item = p.ExplicitNullMarker
 		}

--- a/slices.go
+++ b/slices.go
@@ -175,7 +175,7 @@ func (v *SliceSchema) process(ctx *p.SchemaCtx) {
 		// currently accept nil slices and maps as empty input.
 		var item any
 		if p.IsExplicitNullSource(elem) {
-			item = p.ExplicitNullMarker
+			item = p.ExplicitNullMarker()
 		} else {
 			item = elem.Interface()
 		}

--- a/slices.go
+++ b/slices.go
@@ -164,21 +164,7 @@ func (v *SliceSchema) process(ctx *p.SchemaCtx) {
 	subCtx := ctx.NewSchemaCtx(ctx.Data, ctx.ValPtr, ctx.Path, v.schema.getType())
 	defer subCtx.Free()
 	for idx := 0; idx < refVal.Len(); idx++ {
-		elem := refVal.Index(idx)
-		// Nil pointer elements (both untyped []any{..., nil} and typed
-		// []*T{..., nil}) and interface elements wrapping a typed-nil pointer map
-		// to the sentinel so Nullable() pointer schemas can clear the slot.
-		// Non-Nullable schemas treat the sentinel as zero via IsParseZeroValue.
-		// Non-pointer nillable kinds (slice/map/chan/func) are not caught here on
-		// purpose: a nil sub-slice is not semantically explicit null and emitting
-		// the sentinel would change behavior for non-Nullable schemas that
-		// currently accept nil slices and maps as empty input.
-		var item any
-		if p.IsExplicitNullSource(elem) {
-			item = p.ExplicitNullMarker()
-		} else {
-			item = elem.Interface()
-		}
+		item := refVal.Index(idx).Interface()
 		ptr := destVal.Index(idx).Addr().Interface()
 		k := fmt.Sprintf("[%d]", idx)
 		subCtx.Data = item

--- a/slices.go
+++ b/slices.go
@@ -165,6 +165,12 @@ func (v *SliceSchema) process(ctx *p.SchemaCtx) {
 	defer subCtx.Free()
 	for idx := 0; idx < refVal.Len(); idx++ {
 		item := refVal.Index(idx).Interface()
+		// Untyped-nil slice elements map to the sentinel so Nullable() pointer
+		// schemas can clear the slot. Non-Nullable schemas treat the sentinel as
+		// zero via IsParseZeroValue.
+		if item == nil {
+			item = p.ExplicitNullMarker
+		}
 		ptr := destVal.Index(idx).Addr().Interface()
 		k := fmt.Sprintf("[%d]", idx)
 		subCtx.Data = item


### PR DESCRIPTION
~~This adds a method to the Ptr type, allowing fields to be explicitly set to a nil value where as right now a nil in the input map will not set a pointer to nil on a struct. This allows the pointer on the struct to be set to nil on an opt in basis.~~

~~This also counteracts `NotNil` on the Ptr object, only NotNil or Nullable can be set, not both.~~

This changes the default behavior of Ptr types in the schema to allow setting the value the Ptr is associated with to nil.

BREAKING CHANGE: This is a **breaking change** as it changes the default behavior of Ptr when nil values are explicitly provided as the input on the parsing of a schema. Previously nil values would be treated as if the key was not specified at all. Now nils are treated as a proper "lack of value" in the input, and will try to overwrite the pointer on the destination struct with the value `nil`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved distinction between missing and explicitly null values during schema parsing
  * Fixed pointer field clearing behavior when null is provided
  * Enhanced null handling in nested structures and map data providers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->