### PR TITLE
docs: make tables with sticky header

### DIFF
--- a/docs/docs/core-concepts/parsing-table.tsx
+++ b/docs/docs/core-concepts/parsing-table.tsx
@@ -491,7 +491,7 @@ const schemaData = [
 
 export default function MyTable() {
   return (
-    <div className="">
+    <div className="sticky-table">
       <table>
         <thead>
           <tr>

--- a/docs/docs/core-concepts/validation-table.tsx
+++ b/docs/docs/core-concepts/validation-table.tsx
@@ -244,7 +244,7 @@ const schemaData = [
 
 export default function MyTable() {
   return (
-    <div className="">
+    <div className="sticky-table">
       <table>
         <thead>
           <tr>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -44,3 +44,26 @@
 .sidebar-item--hidden {
   display: none !important;
 }
+
+.sticky-table {
+	max-height: 600px;
+	overflow-y: auto;
+}
+
+.sticky-table table {
+	display: table;
+	width: 100%;
+}
+
+.sticky-table thead {
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	border-collapse: separate;
+}
+
+.sticky-table thead th {
+	z-index: 0;
+	background-color: var(--ifm-color-emphasis-100);
+	background-clip: padding-box;
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -56,14 +56,12 @@
 }
 
 .sticky-table thead {
-	position: sticky;
-	top: 0;
+  position: sticky;
+  top: 0;
 	z-index: 1;
-	border-collapse: separate;
 }
 
 .sticky-table thead th {
-	z-index: 0;
 	background-color: var(--ifm-color-emphasis-100);
 	background-clip: padding-box;
 }


### PR DESCRIPTION
The tables in the docs are long and I had to scroll back up to maintain 
mental context of the comparisons because the tables could not fit my
screen.

This PR aims to make the headers in the table sticky so that users will
always have the context of the comparison in the tables on their screen.

I attached a short video of the new UI:

[Screencast from 2026-05-10 10-15-22.webm](https://github.com/user-attachments/assets/0a669051-6794-48cb-87e9-12f847493835)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables now feature sticky headers that remain visible while scrolling vertically.
  * Added vertical scrolling capability for improved navigation through large table datasets.

* **Style**
  * Enhanced table container styling for consistent full-width rendering, fixed header appearance, and improved scrolling behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Oudwins/zog/pull/222)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->