### PR TITLE
feat!: removing field key and invalid type schema panics

### DIFF
--- a/.agents/skills/zog-best-practices
+++ b/.agents/skills/zog-best-practices
@@ -1,0 +1,1 @@
+../../skills/zog-best-practices

--- a/any.go
+++ b/any.go
@@ -65,7 +65,8 @@ func (v *AnySchema) process(ctx *p.SchemaCtx) {
 
 	destPtr, ok := ctx.ValPtr.(*any)
 	if !ok {
-		p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		ctx.AddIssue(ctx.IssueFromInvalidType("*any", ctx.ValPtr, "parsing an any schema"))
+		return
 	}
 
 	// Handle default/required for nil values
@@ -129,7 +130,8 @@ func (v *AnySchema) validate(ctx *p.SchemaCtx) {
 
 	valPtr, ok := ctx.ValPtr.(*any)
 	if !ok {
-		p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		ctx.AddIssue(ctx.IssueFromInvalidType("*any", ctx.ValPtr, "validating an any schema"))
+		return
 	}
 
 	// Handle default/required for zero values

--- a/any.go
+++ b/any.go
@@ -65,7 +65,9 @@ func (v *AnySchema) process(ctx *p.SchemaCtx) {
 
 	destPtr, ok := ctx.ValPtr.(*any)
 	if !ok {
-		ctx.AddIssue(ctx.IssueFromInvalidType("*any", ctx.ValPtr, "parsing an any schema"))
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of type *any
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("*any", ctx.ValPtr, "parsing an any schema"))
 		return
 	}
 
@@ -130,7 +132,9 @@ func (v *AnySchema) validate(ctx *p.SchemaCtx) {
 
 	valPtr, ok := ctx.ValPtr.(*any)
 	if !ok {
-		ctx.AddIssue(ctx.IssueFromInvalidType("*any", ctx.ValPtr, "validating an any schema"))
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of type *any
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("*any", ctx.ValPtr, "validating an any schema"))
 		return
 	}
 

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -3,6 +3,7 @@ package zog
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	p "github.com/Oudwins/zog/pkgs/internals"
 	"github.com/Oudwins/zog/pkgs/internals/tutils"
@@ -504,4 +505,30 @@ func TestBoolCustomTest(t *testing.T) {
 func TestBoolGetType(t *testing.T) {
 	s := Bool()
 	assert.Equal(t, zconst.TypeBool, s.getType())
+}
+
+func TestBoolInvalidType(t *testing.T) {
+	var nilString *string
+	cases := []struct {
+		Value any
+	}{
+		{Value: "string"},
+		{Value: 12},
+		{Value: time.Now()},
+		{Value: 12.5},
+		{Value: true},
+		{Value: []string{"hello"}},
+		{Value: nil},
+		{Value: nilString},
+	}
+
+	schema := Bool().Required()
+
+	for _, c := range cases {
+		ctx, errs := tutils.FakeContextFromValue(c.Value, "boolean")
+		schema.process(ctx)
+		assert.NotNil(t, errs.List)
+		assert.Equal(t, errs.List[0].Code, zconst.IssueCodeInvalidType)
+
+	}
 }

--- a/boolean_validate_test.go
+++ b/boolean_validate_test.go
@@ -3,9 +3,11 @@ package zog
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	p "github.com/Oudwins/zog/pkgs/internals"
 	"github.com/Oudwins/zog/pkgs/internals/tutils"
+	"github.com/Oudwins/zog/zconst"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -374,4 +376,30 @@ func TestBoolValidateCustomTest(t *testing.T) {
 		t.Errorf("Expected no errors, got %v", errs)
 	}
 	assert.Equal(t, true, dest)
+}
+
+func TestBoolValidateInvalidType(t *testing.T) {
+	var nilString *string
+	cases := []struct {
+		Value any
+	}{
+		{Value: "string"},
+		{Value: 12},
+		{Value: time.Now()},
+		{Value: 12.5},
+		{Value: true},
+		{Value: []string{"hello"}},
+		{Value: nil},
+		{Value: nilString},
+	}
+
+	schema := Bool().Required()
+
+	for _, c := range cases {
+		ctx, errs := tutils.FakeContextFromValue(c.Value, "boolean")
+		schema.validate(ctx)
+		assert.NotNil(t, errs.List)
+		assert.Equal(t, errs.List[0].Code, zconst.IssueCodeInvalidType)
+
+	}
 }

--- a/boxedSchema.go
+++ b/boxedSchema.go
@@ -56,7 +56,10 @@ func (s *BoxedSchema[B, T]) Validate(dest *B, options ...ExecOption) ZogIssueLis
 func (s *BoxedSchema[B, T]) validate(ctx *p.SchemaCtx) {
 	boxPtr, ok := ctx.ValPtr.(*B)
 	if !ok {
-		p.Panicf("BoxedSchema[%T, %T]: Expected valPtr type to correspond with type defined in schema. But it does not. Expected type: %T, got: %T", new(B), new(T), new(*B), ctx.ValPtr)
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of type *B
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer matching boxed schema type", ctx.ValPtr, "validating a boxed schema"))
+		return
 	}
 	unboxed, err := s.unbox(*boxPtr, ctx)
 	if err != nil {
@@ -81,7 +84,10 @@ func (s *BoxedSchema[B, T]) validate(ctx *p.SchemaCtx) {
 func (s *BoxedSchema[B, T]) process(ctx *p.SchemaCtx) {
 	boxPtr, ok := ctx.ValPtr.(*B)
 	if !ok {
-		p.Panicf("BoxedSchema[%T, %T]: Expected valPtr type to correspond with type defined in schema. But it does not. Expected type: %T, got: %T", new(B), new(T), new(*B), ctx.ValPtr)
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of type *B
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer matching boxed schema type", ctx.ValPtr, "processing a boxed schema"))
+		return
 	}
 
 	// 1. Handle ctx.Data - could be B, *B, or raw data

--- a/custom.go
+++ b/custom.go
@@ -51,7 +51,9 @@ func (c *Custom[T]) process(ctx *p.SchemaCtx) {
 	}
 	ptr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		ctx.AddIssue(ctx.IssueFromInvalidType("pointer matching custom schema type", ctx.ValPtr, "parsing a custom schema"))
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of type *T
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer matching custom schema type", ctx.ValPtr, "parsing a custom schema"))
 		return
 	}
 	*ptr = d
@@ -80,7 +82,9 @@ func (c *Custom[T]) validate(ctx *p.SchemaCtx) {
 	ctx.Processor = &c.test
 	ptr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		ctx.AddIssue(ctx.IssueFromInvalidType("pointer matching custom schema type", ctx.ValPtr, "validating a custom schema"))
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of type *T
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer matching custom schema type", ctx.ValPtr, "validating a custom schema"))
 		return
 	}
 	c.test.Func(ptr, ctx)

--- a/custom.go
+++ b/custom.go
@@ -51,7 +51,8 @@ func (c *Custom[T]) process(ctx *p.SchemaCtx) {
 	}
 	ptr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		ctx.AddIssue(ctx.IssueFromInvalidType("pointer matching custom schema type", ctx.ValPtr, "parsing a custom schema"))
+		return
 	}
 	*ptr = d
 
@@ -79,7 +80,8 @@ func (c *Custom[T]) validate(ctx *p.SchemaCtx) {
 	ctx.Processor = &c.test
 	ptr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		ctx.AddIssue(ctx.IssueFromInvalidType("pointer matching custom schema type", ctx.ValPtr, "validating a custom schema"))
+		return
 	}
 	c.test.Func(ptr, ctx)
 }

--- a/maps.go
+++ b/maps.go
@@ -163,10 +163,16 @@ func (v *MapSchema[K, V]) process(ctx *p.SchemaCtx) {
 	}
 
 	// Create destination map
-	destVal := reflect.ValueOf(ctx.ValPtr).Elem()
+	destPtrVal := reflect.ValueOf(ctx.ValPtr)
+	if destPtrVal.Kind() != reflect.Pointer {
+		ctx.AddIssue(ctx.IssueFromInvalidType("pointer to map", ctx.ValPtr, "processing a map schema"))
+		return
+	}
+	destVal := destPtrVal.Elem()
 	destType := destVal.Type()
 	if destType.Kind() != reflect.Map {
-		p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		ctx.AddIssue(ctx.IssueFromInvalidType("map", ctx.ValPtr, "processing a map schema"))
+		return
 	}
 	destMap := reflect.MakeMap(destType)
 

--- a/maps.go
+++ b/maps.go
@@ -65,7 +65,20 @@ func (v *MapSchema[K, V]) Validate(data *map[K]V, options ...ExecOption) ZogIssu
 
 // Internal function to validate the data
 func (v *MapSchema[K, V]) validate(ctx *p.SchemaCtx) {
-	refVal := reflect.ValueOf(ctx.ValPtr).Elem()
+	mapRefVal := reflect.ValueOf(ctx.ValPtr)
+	if !mapRefVal.IsValid() || mapRefVal.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer to map
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer to map", ctx.ValPtr, "validating a map schema"))
+		return
+	}
+	refVal := mapRefVal.Elem()
+	if !refVal.IsValid() || refVal.Kind() != reflect.Map {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a map
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("map", ctx.ValPtr, "validating a map schema"))
+		return
+	}
 	isZeroVal := p.IsZeroValue(ctx.ValPtr)
 
 	if isZeroVal || refVal.Len() == 0 {
@@ -164,14 +177,24 @@ func (v *MapSchema[K, V]) process(ctx *p.SchemaCtx) {
 
 	// Create destination map
 	destPtrVal := reflect.ValueOf(ctx.ValPtr)
-	if destPtrVal.Kind() != reflect.Pointer {
-		ctx.AddIssue(ctx.IssueFromInvalidType("pointer to map", ctx.ValPtr, "processing a map schema"))
+	if !destPtrVal.IsValid() || destPtrVal.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer to map
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer to map", ctx.ValPtr, "processing a map schema"))
 		return
 	}
 	destVal := destPtrVal.Elem()
+	if !destVal.IsValid() {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a map
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("map", ctx.ValPtr, "processing a map schema"))
+		return
+	}
 	destType := destVal.Type()
 	if destType.Kind() != reflect.Map {
-		ctx.AddIssue(ctx.IssueFromInvalidType("map", ctx.ValPtr, "processing a map schema"))
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a map
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("map", ctx.ValPtr, "processing a map schema"))
 		return
 	}
 	destMap := reflect.MakeMap(destType)

--- a/pkgs/internals/Issues.go
+++ b/pkgs/internals/Issues.go
@@ -118,13 +118,6 @@ type ZogIssueList = []*ZogIssue
 // Users should migrate to using ZogIssueList and access paths via issue.Path
 type ZogIssueMap = map[string]ZogIssueList
 
-// INTERNAL ONLY: Interface used to add errors during parsing & validation. It represents a group of errors
-type ZogIssues interface {
-	Add(err *ZogIssue)
-	IsEmpty() bool
-	Free()
-}
-
 // ErrsList - internal structure for collecting issues during schema execution
 type ErrsList struct {
 	List ZogIssueList

--- a/pkgs/internals/contexts.go
+++ b/pkgs/internals/contexts.go
@@ -43,7 +43,7 @@ type Ctx interface {
 	HasErrored() bool
 }
 
-func NewExecCtx(errs ZogIssues, fmter IssueFmtFunc) *ExecCtx {
+func NewExecCtx(errs *ErrsList, fmter IssueFmtFunc) *ExecCtx {
 	c := ExecCtxPool.Get().(*ExecCtx)
 	c.Fmter = fmter
 	c.Errors = errs
@@ -55,7 +55,7 @@ func NewExecCtx(errs ZogIssues, fmter IssueFmtFunc) *ExecCtx {
 
 type ExecCtx struct {
 	Fmter  IssueFmtFunc
-	Errors ZogIssues
+	Errors *ErrsList
 	m      map[string]any
 }
 

--- a/pkgs/internals/contexts.go
+++ b/pkgs/internals/contexts.go
@@ -167,6 +167,14 @@ func (c *SchemaCtx) Issue() *ZogIssue {
 	return NewZogIssue().SetPath(c.Path.ToListClone()).SetDType(c.DType).SetValue(c.Data)
 }
 
+func (c *SchemaCtx) IssueFromInvalidType(expected string, received any, operation string) *ZogIssue {
+	return c.Issue().SetCode(zconst.IssueCodeInvalidType).SetError(zconst.ErrorInvalidTypeMessage(expected, received, c.Path.String(), c.DType, c.Data, operation))
+}
+
+func (c *SchemaCtx) IssueFromMissingStructField(fieldName string) *ZogIssue {
+	return c.Issue().SetCode(zconst.IssueCodeMissingField).SetError(zconst.ErrorMissingStructField(fieldName, c.Path.String(), c.DType, c.Data))
+}
+
 // Please don't depend on this method it may change
 func (c *SchemaCtx) IssueFromTest(test TestInterface, val any) *ZogIssue {
 	e := ZogIssuePool.Get().(*ZogIssue)

--- a/pkgs/internals/panics.go
+++ b/pkgs/internals/panics.go
@@ -3,9 +3,7 @@ package internals
 import "fmt"
 
 const (
-	PanicTypeCast                        = "Zog Panic: Type Cast Error\n Current context: %s\n Expected valPtr type to correspond with type defined in schema. But it does not. Expected type: *%T, got: %T\nFor more information see: https://zog.dev/panics#type-cast-errors"
-	PanicTypeCastCoercer                 = "Zog Panic: Type Cast Error\n Current context: %s\n Expected coercer return value to correspond with type defined in schema. But it does not. Expected type: *%T, got: %T\nFor more information see: https://zog.dev/panics#type-cast-errors"
-	PanicInvalidArgumentsExpectedPointer = "Zog Panic: Expected destination value to be a pointer but it was not. This is generally caused by forgetting to pass a pointer to your Validate/Parse function. Do schema.Validate(&myStruct), not schema.Validate(myStruct) "
+	PanicTypeCastCoercer = "Zog Panic: Type Cast Error\n Current context: %s\n Expected coercer return value to correspond with type defined in schema. But it does not. Expected type: *%T, got: %T\nFor more information see: https://zog.dev/panics#type-cast-errors"
 )
 
 func Panicf(format string, args ...any) {

--- a/pkgs/internals/panics.go
+++ b/pkgs/internals/panics.go
@@ -5,7 +5,6 @@ import "fmt"
 const (
 	PanicTypeCast                        = "Zog Panic: Type Cast Error\n Current context: %s\n Expected valPtr type to correspond with type defined in schema. But it does not. Expected type: *%T, got: %T\nFor more information see: https://zog.dev/panics#type-cast-errors"
 	PanicTypeCastCoercer                 = "Zog Panic: Type Cast Error\n Current context: %s\n Expected coercer return value to correspond with type defined in schema. But it does not. Expected type: *%T, got: %T\nFor more information see: https://zog.dev/panics#type-cast-errors"
-	PanicMissingStructField              = "Zog Panic: Struct Schema Definition Error\n Current context: %s\n Provided struct is missing expected schema key: %s.\n This means you have made a mistake in your schema definition.\nFor more information see: https://zog.dev/panics#schema-definition-errors"
 	PanicInvalidArgumentsExpectedPointer = "Zog Panic: Expected destination value to be a pointer but it was not. This is generally caused by forgetting to pass a pointer to your Validate/Parse function. Do schema.Validate(&myStruct), not schema.Validate(myStruct) "
 )
 

--- a/pkgs/internals/tutils/fakeContext.go
+++ b/pkgs/internals/tutils/fakeContext.go
@@ -1,0 +1,17 @@
+package tutils
+
+import (
+	"github.com/Oudwins/zog/conf"
+	"github.com/Oudwins/zog/pkgs/internals"
+	"github.com/Oudwins/zog/zconst"
+)
+
+func FakeContextFromValue(val any, schemaType zconst.ZogType) (*internals.SchemaCtx, *internals.ErrsList) {
+	errs := internals.NewErrsList()
+	ctx := internals.NewExecCtx(errs, conf.IssueFormatter)
+
+	path := internals.NewPathBuilder()
+	sctx := ctx.NewSchemaCtx(val, val, path, schemaType)
+
+	return sctx, errs
+}

--- a/pointers.go
+++ b/pointers.go
@@ -78,7 +78,19 @@ func (v *PointerSchema) process(ctx *p.SchemaCtx) {
 		return
 	}
 	rv := reflect.ValueOf(ctx.ValPtr)
+	if !rv.IsValid() || rv.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer", ctx.ValPtr, "processing a pointer schema"))
+		return
+	}
 	destPtr := rv.Elem()
+	if !destPtr.IsValid() || destPtr.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer", ctx.ValPtr, "processing a pointer schema"))
+		return
+	}
 	if destPtr.IsNil() {
 		// this sets the primitive also
 		newVal := reflect.New(destPtr.Type().Elem())
@@ -108,6 +120,12 @@ func (v *PointerSchema) Validate(data any, options ...ExecOption) ZogIssueList {
 
 func (v *PointerSchema) validate(ctx *p.SchemaCtx) {
 	rv := reflect.ValueOf(ctx.ValPtr)
+	if !rv.IsValid() || rv.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer", ctx.ValPtr, "validating a pointer schema"))
+		return
+	}
 	destPtr := rv.Elem()
 	if !destPtr.IsValid() || destPtr.IsNil() {
 		if v.required != nil {

--- a/pointers_validate_test.go
+++ b/pointers_validate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Oudwins/zog/pkgs/internals/tutils"
+	"github.com/Oudwins/zog/zconst"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,9 +19,9 @@ func TestValidatePtrPrimitive(t *testing.T) {
 	errs = s.Validate(&out)
 	assert.Empty(t, errs)
 
-	assert.Panics(t, func() {
-		s.Validate(nil)
-	})
+	errs = s.Validate(nil)
+	assert.NotNil(t, errs)
+	assert.Equal(t, zconst.IssueCodeInvalidType, errs[0].Code)
 }
 
 func TestPtrValidateFormatter(t *testing.T) {

--- a/preprocess.go
+++ b/preprocess.go
@@ -36,7 +36,9 @@ func (s *PreprocessSchema[F, T]) process(ctx *p.SchemaCtx) {
 func (s *PreprocessSchema[F, T]) validate(ctx *p.SchemaCtx) {
 	v, ok := ctx.ValPtr.(F)
 	if !ok {
-		ctx.AddIssue(ctx.IssueFromInvalidType("preprocess input type", ctx.ValPtr, "validating a preprocessed schema"))
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of preprocess input type
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("preprocess input type", ctx.ValPtr, "validating a preprocessed schema"))
 		return
 	}
 	out, err := s.fn(v, ctx)

--- a/preprocess.go
+++ b/preprocess.go
@@ -36,7 +36,8 @@ func (s *PreprocessSchema[F, T]) process(ctx *p.SchemaCtx) {
 func (s *PreprocessSchema[F, T]) validate(ctx *p.SchemaCtx) {
 	v, ok := ctx.ValPtr.(F)
 	if !ok {
-		p.Panicf(p.PanicTypeCast, ctx.String(), new(F), ctx.ValPtr)
+		ctx.AddIssue(ctx.IssueFromInvalidType("preprocess input type", ctx.ValPtr, "validating a preprocessed schema"))
+		return
 	}
 	out, err := s.fn(v, ctx)
 	if err != nil {

--- a/slices.go
+++ b/slices.go
@@ -73,7 +73,20 @@ func (v *SliceSchema) Validate(data any, options ...ExecOption) ZogIssueList {
 // Internal function to validate the data
 func (v *SliceSchema) validate(ctx *p.SchemaCtx) {
 
-	refVal := reflect.ValueOf(ctx.ValPtr).Elem() // we use this to set the value to the ptr. But we still reference the ptr everywhere. This is correct even if it seems confusing.
+	sliceRefVal := reflect.ValueOf(ctx.ValPtr)
+	if !sliceRefVal.IsValid() || sliceRefVal.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer to slice
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer to slice", ctx.ValPtr, "validating a slice schema"))
+		return
+	}
+	refVal := sliceRefVal.Elem() // we use this to set the value to the ptr. But we still reference the ptr everywhere. This is correct even if it seems confusing.
+	if !refVal.IsValid() || refVal.Kind() != reflect.Slice {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a slice
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("slice", ctx.ValPtr, "validating a slice schema"))
+		return
+	}
 	// 2. cast data to string & handle default/required
 	isZeroVal := p.IsZeroValue(ctx.ValPtr)
 
@@ -157,7 +170,20 @@ func (v *SliceSchema) process(ctx *p.SchemaCtx) {
 		refVal = reflect.ValueOf(v)
 	}
 
-	destVal := reflect.ValueOf(ctx.ValPtr).Elem()
+	destPtrVal := reflect.ValueOf(ctx.ValPtr)
+	if !destPtrVal.IsValid() || destPtrVal.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer to slice
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer to slice", ctx.ValPtr, "processing a slice schema"))
+		return
+	}
+	destVal := destPtrVal.Elem()
+	if !destVal.IsValid() || destVal.Kind() != reflect.Slice {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a slice
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("slice", ctx.ValPtr, "processing a slice schema"))
+		return
+	}
 	destVal.Set(reflect.MakeSlice(destVal.Type(), refVal.Len(), refVal.Len()))
 
 	// 3.1 tests for slice items

--- a/struct.go
+++ b/struct.go
@@ -88,11 +88,19 @@ func (v *StructSchema) process(ctx *p.SchemaCtx) {
 	// 3. Process / validate struct fields
 	structRefVal := reflect.ValueOf(ctx.ValPtr)
 	kind := structRefVal.Kind()
-	if kind != reflect.Pointer && kind != reflect.Interface {
-		ctx.AddIssue(ctx.IssueFromInvalidType("pointer to struct", ctx.ValPtr, "processing a struct schema"))
+	if !structRefVal.IsValid() || (kind != reflect.Pointer && kind != reflect.Interface) {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer to struct
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer to struct", ctx.ValPtr, "processing a struct schema"))
 		return
 	}
 	structVal := structRefVal.Elem()
+	if !structVal.IsValid() || structVal.Kind() != reflect.Struct {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a struct
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("struct", ctx.ValPtr, "processing a struct schema"))
+		return
+	}
 	subCtx := ctx.NewSchemaCtx(ctx.Data, ctx.ValPtr, ctx.Path, v.getType())
 	defer subCtx.Free()
 	for key, processor := range v.schema {
@@ -153,7 +161,20 @@ func (v *StructSchema) Validate(dataPtr any, options ...ExecOption) ZogIssueList
 
 // Internal function to validate the data
 func (v *StructSchema) validate(ctx *p.SchemaCtx) {
-	refVal := reflect.ValueOf(ctx.ValPtr).Elem()
+	structRefVal := reflect.ValueOf(ctx.ValPtr)
+	if !structRefVal.IsValid() || structRefVal.Kind() != reflect.Pointer {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a pointer to struct
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer to struct", ctx.ValPtr, "validating a struct schema"))
+		return
+	}
+	refVal := structRefVal.Elem()
+	if !refVal.IsValid() || refVal.Kind() != reflect.Struct {
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not a struct
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("struct", ctx.ValPtr, "validating a struct schema"))
+		return
+	}
 
 	// 2. cast data to string & handle default/required
 

--- a/struct.go
+++ b/struct.go
@@ -1,6 +1,7 @@
 package zog
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -105,7 +106,9 @@ func (v *StructSchema) process(ctx *p.SchemaCtx) {
 
 		fieldMeta, ok := structVal.Type().FieldByName(key)
 		if !ok {
-			p.Panicf(p.PanicMissingStructField, ctx.String(), key)
+			ctx.AddIssue(ctx.Issue().SetCode(zconst.IssueCodeMissingField).SetError(errors.New(zconst.ErrorMissingStructField(key))))
+			continue
+			// p.Panicf(p.PanicMissingStructField, ctx.String(), key)
 		}
 		destPtr := structVal.FieldByName(key).Addr().Interface()
 

--- a/struct.go
+++ b/struct.go
@@ -1,7 +1,6 @@
 package zog
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -90,7 +89,8 @@ func (v *StructSchema) process(ctx *p.SchemaCtx) {
 	structRefVal := reflect.ValueOf(ctx.ValPtr)
 	kind := structRefVal.Kind()
 	if kind != reflect.Pointer && kind != reflect.Interface {
-		p.Panicf(p.PanicInvalidArgumentsExpectedPointer)
+		ctx.AddIssue(ctx.IssueFromInvalidType("pointer to struct", ctx.ValPtr, "processing a struct schema"))
+		return
 	}
 	structVal := structRefVal.Elem()
 	subCtx := ctx.NewSchemaCtx(ctx.Data, ctx.ValPtr, ctx.Path, v.getType())
@@ -106,9 +106,8 @@ func (v *StructSchema) process(ctx *p.SchemaCtx) {
 
 		fieldMeta, ok := structVal.Type().FieldByName(key)
 		if !ok {
-			ctx.AddIssue(ctx.Issue().SetCode(zconst.IssueCodeMissingField).SetError(errors.New(zconst.ErrorMissingStructField(key))))
+			ctx.AddIssue(ctx.IssueFromMissingStructField(key))
 			continue
-			// p.Panicf(p.PanicMissingStructField, ctx.String(), key)
 		}
 		destPtr := structVal.FieldByName(key).Addr().Interface()
 

--- a/struct_test.go
+++ b/struct_test.go
@@ -289,9 +289,10 @@ func TestStructPanicsOnSchemaMismatch(t *testing.T) {
 		"bol": true,
 		"tim": "2024-08-06T00:00:00Z",
 	}
-	assert.Panics(t, func() {
-		objSchema.Parse(data, &o)
-	})
+
+	errs := objSchema.Parse(data, &o)
+	assert.NotNil(t, errs)
+	assert.Equal(t, zconst.IssueCodeMissingField, errs[0].Code)
 }
 
 func TestStructPostTransforms(t *testing.T) {

--- a/struct_validate_test.go
+++ b/struct_validate_test.go
@@ -218,18 +218,3 @@ func TestValidateStructGetType(t *testing.T) {
 	})
 	assert.Equal(t, zconst.TypeStruct, s.getType())
 }
-
-func TestValidateStructInvalidSchema(t *testing.T) {
-	schema := Struct(Shape{
-		"field": String(),
-	})
-
-	type TestStruct struct {
-		Field int
-	}
-
-	var dest TestStruct
-	assert.Panics(t, func() {
-		schema.Validate(&dest)
-	})
-}

--- a/zconst/consts.go
+++ b/zconst/consts.go
@@ -73,6 +73,12 @@ const (
 	ErrCodeCoerce   ZogErrCode   = "coerce" // all
 	IssueCodeCoerce ZogIssueCode = "coerce" // all
 
+	// Invalid type happens when you provide a boolean to a schema that expects something else.
+	IssueCodeInvalidType ZogIssueCode = "invalid_type"
+
+	// Missing field happens when you provide a schema shape with a field that is not present in the underlying data structure (generally a struct)
+	IssueCodeMissingField ZogIssueCode = "missing_field"
+
 	// Deprecated: Use IssueCodeFallback instead
 	// all. Applied when other errror code is not implemented. Required to be implemented for every zog type!
 	ErrCodeFallback ZogErrCode = "fallback"
@@ -219,3 +225,19 @@ const (
 	ZogProcessorTransform ZogProcessor = "transform"
 	ZogProcessorRequired  ZogProcessor = "required"
 )
+
+// Error Message Strings
+// Replaces typecast panic:
+// PanicTypeCast                        = "Zog Panic: Type Cast Error\n Current context: %s\n Expected valPtr type to correspond with type defined in schema. But it does not. Expected type: *%T, got: %T\nFor more information see: https://zog.dev/panics#type-cast-errors"
+func ErrorInvalidTypeMessage(expected string, received string) string {
+	return "[Invalid type] zog expected a different type from what was provided. This is an invariant. Unless you are using union schema it means you have made a mistake in your code.\n Expected: " + expected + ". Received: " + received
+}
+
+//
+// replaces
+//
+// PanicMissingStructField              = "Zog Panic: Struct Schema Definition Error\n Current context: %s\n Provided struct is missing expected schema key: %s.\n This means you have made a mistake in your schema definition.\nFor more information see: https://zog.dev/panics#schema-definition-errors"
+
+func ErrorMissingStructField(fieldName string) string {
+	return "[missing structure field] zog expected struct to match schema but it did not. Provided struct is missing expected schema key. If you are not using union shcema it means you have made a mistake in your schema definition.\nFor more information see: https://zog.dev/panics#schema-definition-errors"
+}

--- a/zconst/consts.go
+++ b/zconst/consts.go
@@ -1,5 +1,7 @@
 package zconst
 
+import "fmt"
+
 const (
 	// ISSUE_KEY_ROOT is the key for root-level issues on complex schemas on flattened maps
 	ISSUE_KEY_ROOT = "$root"
@@ -226,18 +228,10 @@ const (
 	ZogProcessorRequired  ZogProcessor = "required"
 )
 
-// Error Message Strings
-// Replaces typecast panic:
-// PanicTypeCast                        = "Zog Panic: Type Cast Error\n Current context: %s\n Expected valPtr type to correspond with type defined in schema. But it does not. Expected type: *%T, got: %T\nFor more information see: https://zog.dev/panics#type-cast-errors"
-func ErrorInvalidTypeMessage(expected string, received string) string {
-	return "[Invalid type] zog expected a different type from what was provided. This is an invariant. Unless you are using union schema it means you have made a mistake in your code.\n Expected: " + expected + ". Received: " + received
+func ErrorInvalidTypeMessage(expected string, received any, path string, dtype ZogType, value any, operation string) error {
+	return fmt.Errorf("[invalid type] zog expected a different type from what was provided while %s. This is an invariant. Unless you are using union schema it means you have made a mistake in your code.\nPath: %q\nSchema type: %s\nExpected: %s\nReceived: %T\nValue: %v", operation, path, dtype, expected, received, value)
 }
 
-//
-// replaces
-//
-// PanicMissingStructField              = "Zog Panic: Struct Schema Definition Error\n Current context: %s\n Provided struct is missing expected schema key: %s.\n This means you have made a mistake in your schema definition.\nFor more information see: https://zog.dev/panics#schema-definition-errors"
-
-func ErrorMissingStructField(fieldName string) string {
-	return "[missing structure field] zog expected struct to match schema but it did not. Provided struct is missing expected schema key. If you are not using union shcema it means you have made a mistake in your schema definition.\nFor more information see: https://zog.dev/panics#schema-definition-errors"
+func ErrorMissingStructField(fieldName string, path string, dtype ZogType, value any) error {
+	return fmt.Errorf("[missing structure field] zog expected struct to match schema but it did not. Provided struct is missing expected schema key. If you are not using union schema it means you have made a mistake in your schema definition.\nPath: %q\nSchema type: %s\nMissing field: %s\nValue: %v\nFor more information see: https://zog.dev/panics#schema-definition-errors", path, dtype, fieldName, value)
 }

--- a/zogSchema.go
+++ b/zogSchema.go
@@ -1,8 +1,6 @@
 package zog
 
 import (
-	"errors"
-
 	p "github.com/Oudwins/zog/pkgs/internals"
 	zss "github.com/Oudwins/zog/pkgs/zss/core"
 	"github.com/Oudwins/zog/zconst"
@@ -59,8 +57,7 @@ func primitiveParsing[T p.ZogPrimitive](ctx *p.SchemaCtx, processors []p.ZProces
 
 	destPtr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		// p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
-		ctx.Errors.Add(ctx.Issue().SetCode(zconst.IssueCodeInvalidType).SetError(errors.New(zconst.ErrorInvalidTypeMessage("TODO", "TODO"))))
+		ctx.Errors.Add(ctx.IssueFromInvalidType("pointer matching primitive schema type", ctx.ValPtr, "parsing a primitive schema"))
 		return
 	}
 
@@ -118,9 +115,8 @@ func primitiveValidation[T p.ZogPrimitive](ctx *p.SchemaCtx, processors []p.ZPro
 
 	valPtr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		ctx.Errors.Add(ctx.Issue().SetCode(zconst.IssueCodeInvalidType).SetError(errors.New(zconst.ErrorInvalidTypeMessage("TODO", "TODO"))))
+		ctx.Errors.Add(ctx.IssueFromInvalidType("pointer matching primitive schema type", ctx.ValPtr, "validating a primitive schema"))
 		return
-		// p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
 	}
 
 	// 2. cast data to string & handle default/required

--- a/zogSchema.go
+++ b/zogSchema.go
@@ -1,6 +1,8 @@
 package zog
 
 import (
+	"errors"
+
 	p "github.com/Oudwins/zog/pkgs/internals"
 	zss "github.com/Oudwins/zog/pkgs/zss/core"
 	"github.com/Oudwins/zog/zconst"
@@ -57,7 +59,9 @@ func primitiveParsing[T p.ZogPrimitive](ctx *p.SchemaCtx, processors []p.ZProces
 
 	destPtr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		// p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		ctx.Errors.Add(ctx.Issue().SetCode(zconst.IssueCodeInvalidType).SetError(errors.New(zconst.ErrorInvalidTypeMessage("TODO", "TODO"))))
+		return
 	}
 
 	// 2. cast data to string & handle default/required
@@ -114,7 +118,9 @@ func primitiveValidation[T p.ZogPrimitive](ctx *p.SchemaCtx, processors []p.ZPro
 
 	valPtr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
+		ctx.Errors.Add(ctx.Issue().SetCode(zconst.IssueCodeInvalidType).SetError(errors.New(zconst.ErrorInvalidTypeMessage("TODO", "TODO"))))
+		return
+		// p.Panicf(p.PanicTypeCast, ctx.String(), ctx.DType, ctx.ValPtr)
 	}
 
 	// 2. cast data to string & handle default/required

--- a/zogSchema.go
+++ b/zogSchema.go
@@ -115,7 +115,9 @@ func primitiveValidation[T p.ZogPrimitive](ctx *p.SchemaCtx, processors []p.ZPro
 
 	valPtr, ok := ctx.ValPtr.(*T)
 	if !ok {
-		ctx.Errors.Add(ctx.IssueFromInvalidType("pointer matching primitive schema type", ctx.ValPtr, "validating a primitive schema"))
+		// We have to go directly to the exec context as that is what formats. We cannot use ctx because it will try to catch the issue and this is an uncatchable issue
+		// since we cannot set the value as its not of type *T
+		ctx.ExecCtx.AddIssue(ctx.IssueFromInvalidType("pointer matching primitive schema type", ctx.ValPtr, "validating a primitive schema"))
 		return
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parsing and validation no longer panic on type mismatches across primitives, pointers, slices, maps, structs, boxed/custom/any, and preprocessing. Instead, the operations record an error and return early so execution can continue safely.

* **New Features**
  * Added consistent error reporting for invalid input types and missing struct fields, with new dedicated issue codes/messages.

* **Tests**
  * Added/updated tests to verify invalid-type handling and missing-field behavior (including nil and non-matching input types).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->